### PR TITLE
fix: remove cargo-shear from pre-commit, add dedicated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -86,3 +86,24 @@ jobs:
 
       - name: Run tests
         run: cargo nextest run
+
+  cargo-shear:
+    name: "cargo shear"
+    runs-on: ubuntu-latest
+    needs: determine_changes
+    if: ${{ needs.determine_changes.outputs.code == 'true' || github.ref == 'refs/heads/main' }}
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+
+      - name: Install Rust toolchain
+        run: rustup show
+
+      - uses: Swatinem/rust-cache@779680da715d629ac1d338a641029a2f4372abb5 # v2.8.2
+
+      - name: Install cargo-shear
+        run: cargo install cargo-shear
+
+      - name: Run cargo shear
+        run: cargo shear

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -29,13 +29,6 @@ repos:
 
   - repo: local
     hooks:
-      - id: cargo-shear
-        name: cargo shear
-        entry: cargo shear
-        language: system
-        types: [toml]
-        pass_filenames: false
-
       - id: cargo-fmt
         name: cargo fmt
         entry: cargo fmt --


### PR DESCRIPTION
## Summary
- Remove `cargo-shear` local hook from `.pre-commit-config.yaml` (it required contributors to have the tool installed globally)
- Add a dedicated `cargo-shear` CI job in `ci.yml` that installs and runs it independently

## Test plan
- [x] All 35 tests pass (`just test`)
- [x] All 16 pre-commit hooks pass (`uvx prek run -a`)
- [ ] CI pre-commit job no longer fails on `cargo shear`

Closes #21
Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)