### PR TITLE
chore: add github-actions ecosystem to dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,3 +6,10 @@ updates:
       interval: "weekly"
     cooldown:
       default-days: 7
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Add `github-actions` package ecosystem to `.github/dependabot.yml` for automatic Action version updates
- Verified all Action SHAs are already up to date via `pinact run`

## Test plan
- [x] All pre-commit hooks pass
- [ ] Dependabot creates PRs for future Action updates

Closes #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)