### PR TITLE
Rust version to 1.91

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ resolver = "2"
 
 [workspace.package]
 edition = "2024"
-rust-version = "1.93"
+rust-version = "1.91"
 homepage = "https://github.com/MatthewMckee4/cram"
 repository = "https://github.com/MatthewMckee4/cram"
 authors = ["Matthew McKee <matthewmckee04@yahoo.co.uk>"]


### PR DESCRIPTION
## Summary

I think this is why the release failed

## Test Plan

We will see