### PR TITLE
feat: fix dark mode Typst rendering and modernize UI

### DIFF
--- a/crates/cram_render/benches/render_throughput.rs
+++ b/crates/cram_render/benches/render_throughput.rs
@@ -3,7 +3,7 @@ use criterion::{Criterion, criterion_group, criterion_main};
 fn bench_heading(c: &mut Criterion) {
     c.bench_function("render_heading", |b| {
         b.iter(|| {
-            cram_render::render("= Hello World").expect("render");
+            cram_render::render("= Hello World", false).expect("render");
         });
     });
 }
@@ -11,7 +11,7 @@ fn bench_heading(c: &mut Criterion) {
 fn bench_body_text(c: &mut Criterion) {
     c.bench_function("render_body_text", |b| {
         b.iter(|| {
-            cram_render::render("This is *bold* and _italic_ text with some content.")
+            cram_render::render("This is *bold* and _italic_ text with some content.", false)
                 .expect("render");
         });
     });
@@ -20,7 +20,7 @@ fn bench_body_text(c: &mut Criterion) {
 fn bench_math(c: &mut Criterion) {
     c.bench_function("render_math", |b| {
         b.iter(|| {
-            cram_render::render("$ integral_0^infinity e^(-x^2) d x = sqrt(pi) / 2 $")
+            cram_render::render("$ integral_0^infinity e^(-x^2) d x = sqrt(pi) / 2 $", false)
                 .expect("render");
         });
     });
@@ -44,7 +44,7 @@ This connects five fundamental constants:
 ";
     c.bench_function("render_complex_card", |b| {
         b.iter(|| {
-            cram_render::render(source).expect("render");
+            cram_render::render(source, false).expect("render");
         });
     });
 }

--- a/crates/cram_render/src/lib.rs
+++ b/crates/cram_render/src/lib.rs
@@ -9,11 +9,18 @@ use world::CramWorld;
 /// Render a Typst source string to PNG bytes at 2× pixel density.
 /// The page is auto-sized to the content (not A4).
 ///
+/// When `dark_mode` is true the text colour is set to white so that
+/// rendered cards remain visible on a dark background.
+///
 /// # Errors
 /// Returns [`RenderError`] if the source fails to compile or produces no pages.
-pub fn render(source: &str) -> Result<Vec<u8>, RenderError> {
-    let preamble =
-        format!("#set page(width: auto, height: auto, margin: 0.6em, fill: none)\n{source}");
+pub fn render(source: &str, dark_mode: bool) -> Result<Vec<u8>, RenderError> {
+    let text_fill = if dark_mode { "white" } else { "black" };
+    let preamble = format!(
+        "#set page(width: auto, height: auto, margin: 0.6em, fill: none)\n\
+         #set text(fill: {text_fill})\n\
+         {source}"
+    );
     let world = CramWorld::new(&preamble);
     let result = typst::compile::<PagedDocument>(&world);
     let document = result.output.map_err(|errors| {
@@ -36,20 +43,20 @@ mod tests {
 
     #[test]
     fn render_heading_produces_png() {
-        let bytes = render("= Hello World").expect("render failed");
+        let bytes = render("= Hello World", false).expect("render failed");
         assert!(!bytes.is_empty());
         assert_eq!(&bytes[..4], b"\x89PNG");
     }
 
     #[test]
     fn render_math_equation() {
-        let bytes = render("$ x^2 + y^2 = z^2 $").expect("math render failed");
+        let bytes = render("$ x^2 + y^2 = z^2 $", false).expect("math render failed");
         assert!(!bytes.is_empty());
     }
 
     #[test]
     fn render_is_compact_not_full_a4() {
-        let bytes = render("= Hello").expect("render failed");
+        let bytes = render("= Hello", false).expect("render failed");
         let img = image::load_from_memory(&bytes).expect("decode failed");
         // A4 at 2x = ~1190x1684px — compact should be much smaller
         assert!(img.width() < 800, "width {} too large", img.width());
@@ -58,20 +65,28 @@ mod tests {
 
     #[test]
     fn render_body_text() {
-        let bytes = render("Hello, this is *bold* and _italic_.").expect("text render failed");
+        let bytes =
+            render("Hello, this is *bold* and _italic_.", false).expect("text render failed");
         assert!(!bytes.is_empty());
     }
 
     #[test]
     fn render_special_characters() {
-        let bytes = render("Symbols: & < > \" ' @").expect("special chars render failed");
+        let bytes = render("Symbols: & < > \" ' @", false).expect("special chars render failed");
         assert_eq!(&bytes[..4], b"\x89PNG");
     }
 
     #[test]
     fn render_multiline_content() {
         let source = "= Title\n\nFirst paragraph.\n\nSecond paragraph with *emphasis*.";
-        let bytes = render(source).expect("multiline render failed");
+        let bytes = render(source, false).expect("multiline render failed");
+        assert_eq!(&bytes[..4], b"\x89PNG");
+    }
+
+    #[test]
+    fn render_dark_mode_produces_png() {
+        let bytes = render("= Dark Mode Test", true).expect("dark mode render failed");
+        assert!(!bytes.is_empty());
         assert_eq!(&bytes[..4], b"\x89PNG");
     }
 }

--- a/crates/cram_render/tests/render_pipeline.rs
+++ b/crates/cram_render/tests/render_pipeline.rs
@@ -3,14 +3,14 @@ use cram_store::Store;
 
 #[test]
 fn render_card_front_produces_png() {
-    let bytes = cram_render::render("= Question\nWhat is Rust?").expect("render");
+    let bytes = cram_render::render("= Question\nWhat is Rust?", false).expect("render");
     assert!(bytes.len() > 100);
     assert_eq!(&bytes[..4], b"\x89PNG");
 }
 
 #[test]
 fn render_card_with_math() {
-    let bytes = cram_render::render("Euler: $e^{i pi} + 1 = 0$").expect("render");
+    let bytes = cram_render::render("Euler: $e^{i pi} + 1 = 0$", false).expect("render");
     assert_eq!(&bytes[..4], b"\x89PNG");
 }
 
@@ -19,13 +19,13 @@ fn render_with_preamble() {
     let preamble = "#set text(size: 16pt)";
     let body = "= Hello\nWorld";
     let source = format!("{preamble}\n{body}");
-    let bytes = cram_render::render(&source).expect("render with preamble");
+    let bytes = cram_render::render(&source, false).expect("render with preamble");
     assert_eq!(&bytes[..4], b"\x89PNG");
 }
 
 #[test]
 fn render_invalid_typst_returns_error() {
-    let result = cram_render::render("#nonexistent-func()");
+    let result = cram_render::render("#nonexistent-func()", false);
     assert!(result.is_err());
 }
 
@@ -44,7 +44,15 @@ fn end_to_end_save_render_cycle() {
 
     let loaded = store.load_deck("RenderTest").expect("load");
     let source = format!("{}\n{}", loaded.preamble, loaded.cards[0].front);
-    let bytes = cram_render::render(&source).expect("render");
+    let bytes = cram_render::render(&source, false).expect("render");
     assert_eq!(&bytes[..4], b"\x89PNG");
     assert!(bytes.len() > 100);
+}
+
+#[test]
+fn render_dark_mode_produces_png() {
+    let bytes =
+        cram_render::render("= Dark Mode\nVisible on dark background", true).expect("dark render");
+    assert!(bytes.len() > 100);
+    assert_eq!(&bytes[..4], b"\x89PNG");
 }

--- a/crates/cram_ui/src/app.rs
+++ b/crates/cram_ui/src/app.rs
@@ -3,6 +3,7 @@ use cram_store::Store;
 use eframe::CreationContext;
 use egui::Context;
 
+use crate::style;
 use crate::{
     deck_list::DeckListView, editor::EditorView, search::SearchView, stats::StatsView,
     study::StudyView,
@@ -345,40 +346,66 @@ impl CramApp {
 
 impl eframe::App for CramApp {
     fn update(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
-        egui::TopBottomPanel::top("topbar").show(ctx, |ui| {
-            ui.horizontal(|ui| {
-                ui.heading("📚 Cram");
-                ui.separator();
-                if ui.button("Decks").clicked() {
-                    self.view = View::DeckList;
-                }
-                if ui.button("Stats").clicked() {
-                    self.view = View::Stats;
-                }
-                if ui.button("Search").clicked() {
-                    self.view = View::Search;
-                }
-                ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    let label = if self.dark_mode { "Light" } else { "Dark" };
-                    if ui.button(label).clicked() {
-                        self.dark_mode = !self.dark_mode;
-                        if self.dark_mode {
-                            ctx.set_visuals(egui::Visuals::dark());
+        egui::TopBottomPanel::top("topbar")
+            .frame(egui::Frame::new().inner_margin(egui::Margin::symmetric(8, 6)))
+            .show(ctx, |ui| {
+                ui.horizontal(|ui| {
+                    ui.heading("📚 Cram");
+                    ui.separator();
+                    let nav = [
+                        ("Decks", View::DeckList),
+                        ("Stats", View::Stats),
+                        ("Search", View::Search),
+                    ];
+                    for (label, target) in nav {
+                        let active =
+                            std::mem::discriminant(&self.view) == std::mem::discriminant(&target);
+                        let btn = if active {
+                            egui::Button::new(
+                                egui::RichText::new(label).color(egui::Color32::WHITE),
+                            )
+                            .fill(style::ACCENT)
+                            .corner_radius(style::BUTTON_RADIUS)
                         } else {
-                            ctx.set_visuals(egui::Visuals::light());
+                            egui::Button::new(label).corner_radius(style::BUTTON_RADIUS)
+                        };
+                        if ui.add(btn).clicked() {
+                            self.view = target;
                         }
                     }
+                    ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                        let icon = if self.dark_mode { "☀" } else { "🌙" };
+                        if ui.button(icon).clicked() {
+                            self.dark_mode = !self.dark_mode;
+                            self.texture_cache.clear();
+                            if self.dark_mode {
+                                ctx.set_visuals(egui::Visuals::dark());
+                            } else {
+                                ctx.set_visuals(egui::Visuals::light());
+                            }
+                        }
+                    });
                 });
             });
-        });
 
         if let Some(err) = &self.error_message.clone() {
-            egui::TopBottomPanel::bottom("errors").show(ctx, |ui| {
-                ui.colored_label(egui::Color32::RED, err);
-                if ui.button("✕").clicked() {
-                    self.error_message = None;
-                }
-            });
+            let bg = if self.dark_mode {
+                egui::Color32::from_rgb(80, 20, 20)
+            } else {
+                egui::Color32::from_rgb(254, 226, 226)
+            };
+            egui::TopBottomPanel::bottom("errors")
+                .frame(egui::Frame::new().fill(bg).inner_margin(8.0))
+                .show(ctx, |ui| {
+                    ui.horizontal(|ui| {
+                        ui.colored_label(egui::Color32::RED, err);
+                        ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
+                            if ui.button("✕").clicked() {
+                                self.error_message = None;
+                            }
+                        });
+                    });
+                });
         }
 
         egui::CentralPanel::default().show(ctx, |ui| {
@@ -473,48 +500,63 @@ impl eframe::App for CramApp {
                 } => {
                     ui.vertical_centered(|ui| {
                         ui.add_space(60.0);
-                        ui.heading("Session Complete");
-                        ui.add_space(16.0);
-                        ui.label(format!("Deck: {deck_name}"));
-                        ui.label(format!("Cards reviewed: {cards_reviewed}"));
-                        let retention = if cards_reviewed > 0 {
-                            correct as f64 / cards_reviewed as f64 * 100.0
-                        } else {
-                            0.0
-                        };
-                        ui.label(format!("Retention: {retention:.0}%"));
-                        let mins = elapsed_secs / 60;
-                        let secs = elapsed_secs % 60;
-                        ui.label(format!("Time: {mins}m {secs}s"));
-                        ui.add_space(16.0);
-                        if ui.button("Back to Decks").clicked() {
-                            self.view = View::DeckList;
-                        }
+                        style::card_frame(ui).show(ui, |ui| {
+                            ui.set_max_width(400.0);
+                            ui.vertical_centered(|ui| {
+                                ui.heading("Session Complete");
+                                ui.add_space(16.0);
+                                ui.label(format!("Deck: {deck_name}"));
+                                ui.label(format!("Cards reviewed: {cards_reviewed}"));
+                                let retention = if cards_reviewed > 0 {
+                                    correct as f64 / cards_reviewed as f64 * 100.0
+                                } else {
+                                    0.0
+                                };
+                                ui.label(format!("Retention: {retention:.0}%"));
+                                let mins = elapsed_secs / 60;
+                                let secs = elapsed_secs % 60;
+                                ui.label(format!("Time: {mins}m {secs}s"));
+                                ui.add_space(16.0);
+                                if ui.add(style::accent_button("Back to Decks")).clicked() {
+                                    self.view = View::DeckList;
+                                }
+                            });
+                        });
                     });
                 }
                 View::NewDeck => {
                     ui.vertical_centered(|ui| {
                         ui.add_space(80.0);
-                        ui.heading("New Deck");
-                        ui.add_space(20.0);
-                        ui.horizontal(|ui| {
-                            ui.label("Name:");
-                            ui.text_edit_singleline(&mut self.new_deck_name);
+                        style::card_frame(ui).show(ui, |ui| {
+                            ui.set_max_width(400.0);
+                            ui.vertical_centered(|ui| {
+                                ui.heading("New Deck");
+                                ui.add_space(20.0);
+                                ui.horizontal(|ui| {
+                                    ui.label("Name:");
+                                    ui.text_edit_singleline(&mut self.new_deck_name);
+                                });
+                                ui.add_space(10.0);
+                                ui.horizontal(|ui| {
+                                    if ui.add(style::accent_button("Create")).clicked()
+                                        && !self.new_deck_name.is_empty()
+                                    {
+                                        let deck = Deck::new(self.new_deck_name.trim(), "");
+                                        if let Err(e) = self.store.save_deck(&deck) {
+                                            self.error_message =
+                                                Some(format!("Failed to save: {e}"));
+                                        } else {
+                                            self.decks.push(deck);
+                                            self.view = View::DeckList;
+                                            self.new_deck_name.clear();
+                                        }
+                                    }
+                                    if ui.button("Cancel").clicked() {
+                                        self.view = View::DeckList;
+                                    }
+                                });
+                            });
                         });
-                        ui.add_space(10.0);
-                        if ui.button("Create").clicked() && !self.new_deck_name.is_empty() {
-                            let deck = Deck::new(self.new_deck_name.trim(), "");
-                            if let Err(e) = self.store.save_deck(&deck) {
-                                self.error_message = Some(format!("Failed to save: {e}"));
-                            } else {
-                                self.decks.push(deck);
-                                self.view = View::DeckList;
-                                self.new_deck_name.clear();
-                            }
-                        }
-                        if ui.button("Cancel").clicked() {
-                            self.view = View::DeckList;
-                        }
                     });
                 }
             }
@@ -564,7 +606,8 @@ impl CramApp {
 
                 egui::ScrollArea::both().show(ui, |ui| {
                     let key = format!("fullscreen-{source}");
-                    match get_or_render(ctx, &key, &source, &mut self.texture_cache) {
+                    let dark_mode = ui.visuals().dark_mode;
+                    match get_or_render(ctx, &key, &source, &mut self.texture_cache, dark_mode) {
                         Ok(tex) => {
                             ui.add(egui::Image::new(&tex).max_width(ui.available_width()));
                         }
@@ -582,11 +625,12 @@ fn get_or_render(
     key: &str,
     source: &str,
     cache: &mut std::collections::HashMap<String, egui::TextureHandle>,
+    dark_mode: bool,
 ) -> Result<egui::TextureHandle, String> {
     if let Some(h) = cache.get(key) {
         return Ok(h.clone());
     }
-    let png = cram_render::render(source).map_err(|e| e.to_string())?;
+    let png = cram_render::render(source, dark_mode).map_err(|e| e.to_string())?;
     let img = image::load_from_memory(&png).map_err(|e| e.to_string())?;
     let rgba = img.to_rgba8();
     let (w, h) = rgba.dimensions();

--- a/crates/cram_ui/src/deck_list.rs
+++ b/crates/cram_ui/src/deck_list.rs
@@ -3,6 +3,7 @@ use cram_store::Store;
 use egui::Ui;
 
 use crate::app::View;
+use crate::style;
 
 pub struct DeckListView;
 
@@ -19,7 +20,7 @@ impl DeckListView {
             ui.horizontal(|ui| {
                 ui.heading("Your Decks");
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if ui.button("＋ New Deck").clicked() {
+                    if ui.add(style::accent_button("＋ New Deck")).clicked() {
                         *new_deck_name = String::new();
                         *view = View::NewDeck;
                     }
@@ -37,7 +38,7 @@ impl DeckListView {
                     ui.add_space(8.0);
                     ui.label("Create your first deck to start studying!");
                     ui.add_space(16.0);
-                    if ui.button("＋ Create Deck").clicked() {
+                    if ui.add(style::accent_button("＋ Create Deck")).clicked() {
                         *new_deck_name = String::new();
                         *view = View::NewDeck;
                     }
@@ -53,65 +54,74 @@ impl DeckListView {
                         let due = deck.due_count();
                         let total = deck.cards.len();
 
-                        egui::Frame::new()
-                            .fill(ui.visuals().extreme_bg_color)
-                            .corner_radius(8.0)
-                            .inner_margin(12.0)
-                            .show(ui, |ui| {
-                                ui.set_min_width(200.0);
-                                ui.vertical(|ui| {
-                                    ui.heading(&deck.name);
-                                    if !deck.description.is_empty() {
-                                        ui.label(
-                                            egui::RichText::new(&deck.description)
-                                                .italics()
-                                                .color(ui.visuals().weak_text_color()),
-                                        );
+                        style::card_frame(ui).show(ui, |ui| {
+                            ui.set_min_width(200.0);
+                            ui.vertical(|ui| {
+                                ui.heading(&deck.name);
+                                if !deck.description.is_empty() {
+                                    ui.label(
+                                        egui::RichText::new(&deck.description)
+                                            .italics()
+                                            .color(ui.visuals().weak_text_color()),
+                                    );
+                                }
+                                ui.label(format!("{total} cards"));
+                                if due > 0 {
+                                    egui::Frame::new()
+                                        .fill(egui::Color32::from_rgb(255, 165, 0))
+                                        .corner_radius(10.0)
+                                        .inner_margin(egui::Margin::symmetric(8, 2))
+                                        .show(ui, |ui| {
+                                            ui.label(
+                                                egui::RichText::new(format!("{due} due"))
+                                                    .color(egui::Color32::WHITE)
+                                                    .strong(),
+                                            );
+                                        });
+                                } else {
+                                    ui.colored_label(egui::Color32::GREEN, "Up to date ✓");
+                                }
+                                ui.add_space(8.0);
+                                ui.horizontal(|ui| {
+                                    if ui.add(style::accent_button("Study")).clicked() {
+                                        *view = View::Study {
+                                            deck_name: deck.name.clone(),
+                                            card_index: 0,
+                                            revealed: false,
+                                        };
                                     }
-                                    ui.label(format!("{total} cards"));
-                                    if due > 0 {
-                                        ui.colored_label(
-                                            egui::Color32::from_rgb(255, 165, 0),
-                                            format!("{due} due"),
-                                        );
-                                    } else {
-                                        ui.colored_label(egui::Color32::GREEN, "Up to date ✓");
+                                    if ui
+                                        .add(
+                                            egui::Button::new("Edit")
+                                                .corner_radius(style::BUTTON_RADIUS),
+                                        )
+                                        .clicked()
+                                    {
+                                        *view = View::Editor {
+                                            deck_name: deck.name.clone(),
+                                            card_index: None,
+                                        };
                                     }
-                                    ui.add_space(8.0);
-                                    ui.horizontal(|ui| {
-                                        if ui.button("Study").clicked() {
-                                            *view = View::Study {
-                                                deck_name: deck.name.clone(),
-                                                card_index: 0,
-                                                revealed: false,
-                                            };
-                                        }
-                                        if ui.button("Edit").clicked() {
-                                            *view = View::Editor {
-                                                deck_name: deck.name.clone(),
-                                                card_index: None,
-                                            };
-                                        }
-                                    });
-                                    ui.horizontal(|ui| {
-                                        if ui.small_button("Import CSV").clicked() {
-                                            *view = View::ImportCsv {
-                                                deck_name: deck.name.clone(),
-                                            };
-                                        }
-                                        if ui.small_button("Export CSV").clicked() {
-                                            *view = View::ExportCsv {
-                                                deck_name: deck.name.clone(),
-                                            };
-                                        }
-                                        if ui.small_button("Deck Stats").clicked() {
-                                            *view = View::DeckStats {
-                                                deck_name: deck.name.clone(),
-                                            };
-                                        }
-                                    });
+                                });
+                                ui.horizontal(|ui| {
+                                    if ui.small_button("Import CSV").clicked() {
+                                        *view = View::ImportCsv {
+                                            deck_name: deck.name.clone(),
+                                        };
+                                    }
+                                    if ui.small_button("Export CSV").clicked() {
+                                        *view = View::ExportCsv {
+                                            deck_name: deck.name.clone(),
+                                        };
+                                    }
+                                    if ui.small_button("Deck Stats").clicked() {
+                                        *view = View::DeckStats {
+                                            deck_name: deck.name.clone(),
+                                        };
+                                    }
                                 });
                             });
+                        });
 
                         if (i + 1) % 3 == 0 {
                             ui.end_row();

--- a/crates/cram_ui/src/editor.rs
+++ b/crates/cram_ui/src/editor.rs
@@ -4,6 +4,7 @@ use egui::{Context, Ui};
 
 use crate::app::PreviewDebounce;
 use crate::highlight::typst_layout_job;
+use crate::style;
 
 pub struct EditorView;
 
@@ -30,7 +31,7 @@ impl EditorView {
             ui.horizontal(|ui| {
                 ui.heading(format!("Edit: {deck_name}"));
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if ui.button("+ Add Card").clicked() {
+                    if ui.add(style::accent_button("+ Add Card")).clicked() {
                         deck.cards.push(Card::new("Front", "Back"));
                         let _ = store.save_deck(deck);
                     }
@@ -56,7 +57,10 @@ impl EditorView {
                 }
                 if !selected_cards.is_empty()
                     && ui
-                        .button(format!("Delete Selected ({})", selected_cards.len()))
+                        .add(style::destructive_button(&format!(
+                            "Delete Selected ({})",
+                            selected_cards.len()
+                        )))
                         .clicked()
                 {
                     let mut indices: Vec<usize> = selected_cards.iter().copied().collect();
@@ -202,7 +206,14 @@ impl EditorView {
                                             preview_debounce.render_source(i, &front, ctx);
                                         let source = with_preamble(&deck.preamble, &debounced);
                                         let key = format!("editor-{i}-{source}");
-                                        match get_or_render(ctx, &key, &source, texture_cache) {
+                                        let dark_mode = ui.visuals().dark_mode;
+                                        match get_or_render(
+                                            ctx,
+                                            &key,
+                                            &source,
+                                            texture_cache,
+                                            dark_mode,
+                                        ) {
                                             Ok(tex) => {
                                                 ui.add(egui::Image::new(&tex).max_width(col_w));
                                             }
@@ -218,11 +229,11 @@ impl EditorView {
 
                                 ui.add_space(4.0);
                                 ui.horizontal(|ui| {
-                                    if ui.button("Save").clicked() {
+                                    if ui.add(style::accent_button("Save")).clicked() {
                                         save_now = true;
                                         texture_cache.clear();
                                     }
-                                    if ui.button("Delete").clicked() {
+                                    if ui.add(style::destructive_button("Delete")).clicked() {
                                         to_delete = Some(i);
                                     }
                                 });
@@ -256,11 +267,12 @@ fn get_or_render(
     key: &str,
     source: &str,
     cache: &mut std::collections::HashMap<String, egui::TextureHandle>,
+    dark_mode: bool,
 ) -> Result<egui::TextureHandle, String> {
     if let Some(h) = cache.get(key) {
         return Ok(h.clone());
     }
-    let png = cram_render::render(source).map_err(|e| e.to_string())?;
+    let png = cram_render::render(source, dark_mode).map_err(|e| e.to_string())?;
     let img = image::load_from_memory(&png).map_err(|e| e.to_string())?;
     let rgba = img.to_rgba8();
     let (w, h) = rgba.dimensions();

--- a/crates/cram_ui/src/lib.rs
+++ b/crates/cram_ui/src/lib.rs
@@ -5,5 +5,6 @@ mod highlight;
 mod search;
 mod stats;
 mod study;
+mod style;
 
 pub use app::CramApp;

--- a/crates/cram_ui/src/search.rs
+++ b/crates/cram_ui/src/search.rs
@@ -1,6 +1,8 @@
 use cram_core::Deck;
 use egui::Ui;
 
+use crate::style;
+
 pub struct SearchView;
 
 impl SearchView {
@@ -44,14 +46,10 @@ impl SearchView {
                     ui.separator();
 
                     for card in matches {
-                        egui::Frame::new()
-                            .fill(ui.visuals().extreme_bg_color)
-                            .corner_radius(6.0)
-                            .inner_margin(8.0)
-                            .show(ui, |ui| {
-                                ui.label(egui::RichText::new(&card.front).strong());
-                                ui.label(&card.back);
-                            });
+                        style::card_frame(ui).inner_margin(12.0).show(ui, |ui| {
+                            ui.label(egui::RichText::new(&card.front).strong());
+                            ui.label(&card.back);
+                        });
                         ui.add_space(4.0);
                     }
                     ui.add_space(8.0);

--- a/crates/cram_ui/src/stats.rs
+++ b/crates/cram_ui/src/stats.rs
@@ -1,6 +1,8 @@
 use cram_core::Deck;
 use egui::Ui;
 
+use crate::style;
+
 pub struct StatsView;
 
 impl StatsView {
@@ -30,24 +32,25 @@ impl StatsView {
             ui.separator();
             ui.add_space(16.0);
 
-            egui::Grid::new("stats_grid")
-                .num_columns(2)
-                .spacing([24.0, 12.0])
-                .show(ui, |ui| {
-                    stat_row(ui, "Total cards", &total_cards.to_string());
-                    stat_row(ui, "Due today", &due_today.to_string());
-                    stat_row(ui, "Cards reviewed", &reviewed.to_string());
-                    stat_row(ui, "Retention rate", &format!("{retention_pct:.0}%"));
-                    stat_row(ui, "Study streak", &format!("{streak} day(s)"));
-                });
+            ui.horizontal_wrapped(|ui| {
+                stat_card(ui, "Total cards", &total_cards.to_string());
+                stat_card(ui, "Due today", &due_today.to_string());
+                stat_card(ui, "Reviewed", &reviewed.to_string());
+                stat_card(ui, "Retention", &format!("{retention_pct:.0}%"));
+                stat_card(ui, "Streak", &format!("{streak} day(s)"));
+            });
         });
     }
 }
 
-fn stat_row(ui: &mut egui::Ui, label: &str, value: &str) {
-    ui.label(label);
-    ui.heading(value);
-    ui.end_row();
+fn stat_card(ui: &mut egui::Ui, label: &str, value: &str) {
+    style::card_frame(ui).show(ui, |ui| {
+        ui.set_min_width(100.0);
+        ui.vertical_centered(|ui| {
+            ui.label(label);
+            ui.heading(value);
+        });
+    });
 }
 
 /// Compute streak as the number of consecutive days (ending today or yesterday)

--- a/crates/cram_ui/src/study.rs
+++ b/crates/cram_ui/src/study.rs
@@ -3,6 +3,7 @@ use cram_store::Store;
 use egui::{Context, Ui};
 
 use crate::app::{UndoState, View};
+use crate::style;
 
 pub struct StudyView;
 
@@ -85,34 +86,32 @@ impl StudyView {
                 format!("{}\n{card_text}", deck.preamble)
             };
 
-            let render_result = get_or_render(ctx, &card_source, &card_source, texture_cache);
+            let dark_mode = ui.visuals().dark_mode;
+            let render_result =
+                get_or_render(ctx, &card_source, &card_source, texture_cache, dark_mode);
 
-            egui::Frame::new()
-                .fill(ui.visuals().window_fill)
-                .corner_radius(12.0)
-                .inner_margin(24.0)
-                .stroke(ui.visuals().window_stroke)
-                .show(ui, |ui| {
-                    ui.set_min_size(egui::vec2(ui.available_width(), 320.0));
-                    ui.vertical_centered(|ui| match &render_result {
-                        Ok(tex) => {
-                            let max_w = ui.available_width().min(600.0);
-                            ui.add(egui::Image::new(tex).max_width(max_w));
-                        }
-                        Err(err) => {
-                            ui.colored_label(egui::Color32::RED, format!("Render error: {err}"));
-                            ui.label(&card_source);
-                        }
-                    });
+            style::card_frame(ui).inner_margin(24.0).show(ui, |ui| {
+                ui.set_min_size(egui::vec2(ui.available_width(), 320.0));
+                ui.vertical_centered(|ui| match &render_result {
+                    Ok(tex) => {
+                        let max_w = ui.available_width().min(600.0);
+                        ui.add(egui::Image::new(tex).max_width(max_w));
+                    }
+                    Err(err) => {
+                        ui.colored_label(egui::Color32::RED, format!("Render error: {err}"));
+                        ui.label(&card_source);
+                    }
                 });
+            });
 
             ui.add_space(16.0);
 
             if !*revealed {
                 ui.vertical_centered(|ui| {
-                    if ui.button("Show Answer  [Space]").clicked()
-                        || ui.input(|i| i.key_pressed(egui::Key::Space))
-                    {
+                    let btn = style::accent_button("Show Answer  [Space]")
+                        .min_size(egui::vec2(200.0, 40.0))
+                        .corner_radius(8.0);
+                    if ui.add(btn).clicked() || ui.input(|i| i.key_pressed(egui::Key::Space)) {
                         *revealed = true;
                     }
                 });
@@ -146,7 +145,11 @@ impl StudyView {
                     for (rating, color, key) in ratings {
                         let text = format!("{} [{}]", rating.label(), key);
                         let label = egui::RichText::new(text).color(egui::Color32::WHITE);
-                        if ui.add(egui::Button::new(label).fill(color)).clicked() {
+                        let btn = egui::Button::new(label)
+                            .fill(color)
+                            .corner_radius(style::BUTTON_RADIUS)
+                            .min_size(egui::vec2(80.0, 32.0));
+                        if ui.add(btn).clicked() {
                             selected_rating = Some(rating);
                         }
                     }
@@ -212,11 +215,12 @@ fn get_or_render(
     key: &str,
     source: &str,
     cache: &mut std::collections::HashMap<String, egui::TextureHandle>,
+    dark_mode: bool,
 ) -> Result<egui::TextureHandle, String> {
     if let Some(h) = cache.get(key) {
         return Ok(h.clone());
     }
-    let png = cram_render::render(source).map_err(|e| e.to_string())?;
+    let png = cram_render::render(source, dark_mode).map_err(|e| e.to_string())?;
     let img = image::load_from_memory(&png).map_err(|e| e.to_string())?;
     let rgba = img.to_rgba8();
     let (w, h) = rgba.dimensions();

--- a/crates/cram_ui/src/style.rs
+++ b/crates/cram_ui/src/style.rs
@@ -1,0 +1,43 @@
+use egui::{Color32, Shadow, Stroke, Ui};
+
+pub const CARD_RADIUS: f32 = 10.0;
+pub const BUTTON_RADIUS: f32 = 6.0;
+pub const CARD_MARGIN: f32 = 16.0;
+pub const ACCENT: Color32 = Color32::from_rgb(59, 130, 246);
+pub const DESTRUCTIVE: Color32 = Color32::from_rgb(220, 50, 50);
+
+pub fn card_shadow() -> Shadow {
+    Shadow {
+        spread: 0,
+        blur: 8,
+        offset: [0, 2],
+        color: Color32::from_black_alpha(20),
+    }
+}
+
+/// Standard card frame used across all views.
+pub fn card_frame(ui: &Ui) -> egui::Frame {
+    egui::Frame::new()
+        .fill(ui.visuals().faint_bg_color)
+        .corner_radius(CARD_RADIUS)
+        .inner_margin(CARD_MARGIN)
+        .shadow(card_shadow())
+        .stroke(Stroke::new(
+            1.0,
+            ui.visuals().widgets.noninteractive.bg_stroke.color,
+        ))
+}
+
+/// Primary action button with accent fill and white text.
+pub fn accent_button(text: &str) -> egui::Button<'_> {
+    egui::Button::new(egui::RichText::new(text).color(Color32::WHITE))
+        .fill(ACCENT)
+        .corner_radius(BUTTON_RADIUS)
+}
+
+/// Destructive action button with red fill and white text.
+pub fn destructive_button(text: &str) -> egui::Button<'_> {
+    egui::Button::new(egui::RichText::new(text).color(Color32::WHITE))
+        .fill(DESTRUCTIVE)
+        .corner_radius(BUTTON_RADIUS)
+}


### PR DESCRIPTION
## Summary

- **Fix dark mode rendering**: Typst-rendered card text was invisible in dark mode (black text on dark background). Added `dark_mode: bool` parameter to `render()` that injects `#set text(fill: white)` when active, with texture cache invalidation on theme toggle.
- **Shared style module**: New `style.rs` with consistent design tokens (card radius, shadow, accent/destructive colors) and helper functions (`card_frame()`, `accent_button()`, `destructive_button()`).
- **UI modernization**: Applied consistent styling across all views — card frames with `faint_bg_color` and shadows, accent-colored primary buttons, destructive red buttons, active nav highlighting in topbar, pill-style due count badges, themed error bar, and sun/moon theme toggle icons.

## Test plan

- [x] All 56 existing tests pass (`cargo test`)
- [x] New `render_dark_mode_produces_png` tests added (unit + integration)
- [x] All pre-commit hooks pass (`uvx prek run -a`)
- [ ] Manual: launch GUI, verify dark mode card text is white/visible
- [ ] Manual: toggle to light mode, verify card text is black/visible
- [ ] Manual: check all views for consistent styling