### PR TITLE
feat: add --prerelease flag to self update

### DIFF
--- a/crates/cram/src/main.rs
+++ b/crates/cram/src/main.rs
@@ -30,6 +30,9 @@ enum SelfCommand {
         /// GitHub API token for authentication (avoids rate limits)
         #[arg(long)]
         token: Option<String>,
+        /// Include pre-release versions (e.g. alpha, beta, rc)
+        #[arg(long)]
+        prerelease: bool,
     },
 }
 
@@ -48,8 +51,8 @@ fn main() {
             }
         }
         Some(Command::Self_ { command }) => match command {
-            SelfCommand::Update { token } => {
-                if let Err(e) = self_update(token) {
+            SelfCommand::Update { token, prerelease } => {
+                if let Err(e) = self_update(token, prerelease) {
                     eprintln!("cram: {e}");
                     std::process::exit(1);
                 }
@@ -59,11 +62,15 @@ fn main() {
     }
 }
 
-fn self_update(token: Option<String>) -> anyhow::Result<()> {
+fn self_update(token: Option<String>, prerelease: bool) -> anyhow::Result<()> {
     let mut updater = axoupdater::AxoUpdater::new_for("cram");
 
     if let Some(ref token) = token {
         updater.set_github_token(token);
+    }
+
+    if prerelease {
+        updater.configure_version_specifier(axoupdater::UpdateRequest::LatestMaybePrerelease);
     }
 
     if let Err(e) = updater.load_receipt() {


### PR DESCRIPTION
## Summary

- Add `--prerelease` flag to `cram self update` that allows updating to pre-release versions (alpha, beta, rc)
- Without this flag, axoupdater only considers stable releases, so users on pre-release builds like `0.0.1-alpha.0` cannot update to newer pre-releases
- Uses `axoupdater::UpdateRequest::LatestMaybePrerelease` when the flag is set

### Usage

```sh
# Update to latest stable release (existing behavior, unchanged)
cram self update

# Update to latest release including pre-releases
cram self update --prerelease
```

Closes #45

## Test plan

- [x] `cargo test` — all tests pass
- [x] `cargo check` — compiles cleanly
- [x] `uvx prek run -a` — all pre-commit hooks pass
- [ ] Manual: `cram self update --help` shows the new `--prerelease` flag
- [ ] Manual: `cram self update --prerelease` checks for pre-release versions