### PR TITLE
refactor: move clap structs to new `cram_cli` crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1228,11 +1228,19 @@ dependencies = [
  "anyhow",
  "axoupdater",
  "clap",
+ "cram_cli",
  "cram_store",
  "cram_ui",
  "eframe",
  "egui",
  "tracing-subscriber",
+]
+
+[[package]]
+name = "cram_cli"
+version = "0.0.0"
+dependencies = [
+ "clap",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ authors = ["Matthew McKee <matthewmckee04@yahoo.co.uk>"]
 license = "MIT"
 
 [workspace.dependencies]
+cram_cli = { path = "crates/cram_cli" }
 cram_core = { path = "crates/cram_core" }
 cram_render = { path = "crates/cram_render" }
 cram_store = { path = "crates/cram_store" }

--- a/crates/cram/Cargo.toml
+++ b/crates/cram/Cargo.toml
@@ -16,6 +16,7 @@ path = "src/main.rs"
 anyhow.workspace = true
 axoupdater.workspace = true
 clap.workspace = true
+cram_cli.workspace = true
 cram_store.workspace = true
 cram_ui.workspace = true
 eframe.workspace = true

--- a/crates/cram/src/main.rs
+++ b/crates/cram/src/main.rs
@@ -1,42 +1,7 @@
 mod commands;
 
-use clap::{Parser, Subcommand};
-
-#[derive(Parser)]
-#[command(
-    name = "cram",
-    version,
-    about = "A flashcard app with Typst-powered card rendering"
-)]
-struct Cli {
-    #[command(subcommand)]
-    command: Option<Command>,
-}
-
-#[derive(Subcommand)]
-enum Command {
-    /// List all decks
-    List,
-    /// Manage the cram installation
-    #[command(name = "self")]
-    Self_ {
-        #[command(subcommand)]
-        command: SelfCommand,
-    },
-}
-
-#[derive(Subcommand)]
-enum SelfCommand {
-    /// Update cram to the latest version
-    Update {
-        /// GitHub API token for authentication (avoids rate limits)
-        #[arg(long)]
-        token: Option<String>,
-        /// Include pre-release versions (e.g. alpha, beta, rc)
-        #[arg(long)]
-        prerelease: bool,
-    },
-}
+use clap::Parser;
+use cram_cli::{Cli, Command, SelfCommand};
 
 fn main() {
     tracing_subscriber::fmt()

--- a/crates/cram_cli/Cargo.toml
+++ b/crates/cram_cli/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "cram_cli"
+version = "0.0.0"
+edition.workspace = true
+authors.workspace = true
+license.workspace = true
+
+[dependencies]
+clap.workspace = true

--- a/crates/cram_cli/src/lib.rs
+++ b/crates/cram_cli/src/lib.rs
@@ -1,0 +1,37 @@
+use clap::{Parser, Subcommand};
+
+#[derive(Parser)]
+#[command(
+    name = "cram",
+    version,
+    about = "A flashcard app with Typst-powered card rendering"
+)]
+pub struct Cli {
+    #[command(subcommand)]
+    pub command: Option<Command>,
+}
+
+#[derive(Subcommand)]
+pub enum Command {
+    /// List all decks
+    List,
+    /// Manage the cram installation
+    #[command(name = "self")]
+    Self_ {
+        #[command(subcommand)]
+        command: SelfCommand,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum SelfCommand {
+    /// Update cram to the latest version
+    Update {
+        /// GitHub API token for authentication (avoids rate limits)
+        #[arg(long)]
+        token: Option<String>,
+        /// Include pre-release versions (e.g. alpha, beta, rc)
+        #[arg(long)]
+        prerelease: bool,
+    },
+}


### PR DESCRIPTION
## Summary
- Create new `cram_cli` library crate containing CLI parsing types (`Cli`, `Command`, `SelfCommand`)
- Remove inline clap struct definitions from `main.rs`, importing from `cram_cli` instead
- `main.rs` now only handles dispatching commands to their handlers

Closes #49

## Test plan
- [x] `cargo build -p cram` compiles cleanly
- [x] All 41 tests pass (`cargo test`)
- [x] All pre-commit hooks pass (`uvx prek run -a`)