### PR TITLE
Add hidden flag to cards to skip them during study

### DIFF
--- a/crates/cram_core/src/card.rs
+++ b/crates/cram_core/src/card.rs
@@ -11,6 +11,12 @@ pub struct Card {
     review: Option<ReviewState>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     tags: Vec<String>,
+    #[serde(default, skip_serializing_if = "is_false")]
+    hidden: bool,
+}
+
+fn is_false(b: &bool) -> bool {
+    !*b
 }
 
 /// Spaced-repetition scheduling state for a single card (SM-2 algorithm).
@@ -45,6 +51,7 @@ impl Card {
             back: back.into(),
             review: None,
             tags: Vec::new(),
+            hidden: false,
         }
     }
 
@@ -86,6 +93,14 @@ impl Card {
 
     pub fn has_tag(&self, tag: &str) -> bool {
         self.tags.iter().any(|t| t == tag)
+    }
+
+    pub fn is_hidden(&self) -> bool {
+        self.hidden
+    }
+
+    pub fn set_hidden(&mut self, hidden: bool) {
+        self.hidden = hidden;
     }
 }
 
@@ -154,6 +169,41 @@ mod tests {
         let state = ReviewState::default();
         card.set_review(state.clone());
         assert_eq!(card.review(), Some(&state));
+    }
+
+    #[test]
+    fn new_card_is_not_hidden() {
+        let card = Card::new("Q", "A");
+        assert!(!card.is_hidden());
+    }
+
+    #[test]
+    fn set_hidden_updates_state() {
+        let mut card = Card::new("Q", "A");
+        card.set_hidden(true);
+        assert!(card.is_hidden());
+        card.set_hidden(false);
+        assert!(!card.is_hidden());
+    }
+
+    #[test]
+    fn deserialize_missing_hidden_as_false() {
+        let toml_str = r#"
+            id = "00000000-0000-0000-0000-000000000001"
+            front = "Q"
+            back = "A"
+        "#;
+        let card: Card = toml::from_str(toml_str).expect("valid toml");
+        assert!(!card.is_hidden());
+    }
+
+    #[test]
+    fn hidden_roundtrips_through_toml() {
+        let mut card = Card::new("Q", "A");
+        card.set_hidden(true);
+        let s = toml::to_string(&card).expect("serialize");
+        let parsed: Card = toml::from_str(&s).expect("deserialize");
+        assert!(parsed.is_hidden());
     }
 
     #[test]

--- a/crates/cram_ui/src/deck_detail.rs
+++ b/crates/cram_ui/src/deck_detail.rs
@@ -11,6 +11,14 @@ pub enum DeckDetailAction {
     Delete(String),
 }
 
+/// Indices of cards matching the tag filter, excluding hidden cards.
+fn visible_indices(deck: &Deck, tags: &BTreeSet<String>) -> Vec<usize> {
+    deck.card_indices_matching_tags(tags)
+        .into_iter()
+        .filter(|&i| !deck.cards()[i].is_hidden())
+        .collect()
+}
+
 pub struct DeckDetailView;
 
 impl DeckDetailView {
@@ -101,7 +109,7 @@ impl DeckDetailView {
                         .selectable_label(false, egui::RichText::new("Study (Random)").size(15.0))
                         .clicked()
                     {
-                        let indices = deck.card_indices_matching_tags(study_tag_filter);
+                        let indices = visible_indices(deck, study_tag_filter);
                         *view = View::Study(StudyState {
                             deck_name: deck.name().to_string(),
                             card_index: 0,
@@ -150,7 +158,7 @@ impl DeckDetailView {
                     }
                 });
                 if !study_tag_filter.is_empty() {
-                    let filtered = deck.card_indices_matching_tags(study_tag_filter);
+                    let filtered = visible_indices(deck, study_tag_filter);
                     ui.label(
                         egui::RichText::new(format!("{}/{total} cards match", filtered.len()))
                             .small()

--- a/crates/cram_ui/src/deck_list.rs
+++ b/crates/cram_ui/src/deck_list.rs
@@ -145,12 +145,13 @@ pub(crate) fn shuffled_indices_from(mut indices: Vec<usize>) -> Vec<usize> {
 }
 
 /// Return indices of cards that are due for review today.
+/// Hidden cards are excluded.
 pub(crate) fn due_indices(deck: &Deck) -> Vec<usize> {
     let today = Utc::now().date_naive();
     deck.cards()
         .iter()
         .enumerate()
-        .filter(|(_, card)| sm2::is_due(card.review(), today))
+        .filter(|(_, card)| !card.is_hidden() && sm2::is_due(card.review(), today))
         .map(|(i, _)| i)
         .collect()
 }

--- a/crates/cram_ui/src/editor.rs
+++ b/crates/cram_ui/src/editor.rs
@@ -165,6 +165,13 @@ impl EditorView {
                                     ui.spacing_mut().interact_size.y = 28.0;
                                     ui.label(egui::RichText::new(format!("#{}", i + 1)).strong());
                                     ui.label(egui::RichText::new(&preview).weak().italics());
+                                    if deck.cards()[i].is_hidden() {
+                                        ui.label(
+                                            egui::RichText::new("hidden")
+                                                .small()
+                                                .color(ui.visuals().weak_text_color()),
+                                        );
+                                    }
                                     for tag in deck.cards()[i].tags() {
                                         ui.label(
                                             egui::RichText::new(tag).small().color(style::ACCENT),
@@ -249,6 +256,17 @@ impl EditorView {
                                                 .desired_width(col_w)
                                                 .layouter(&mut back_layouter),
                                             );
+
+                                            ui.add_space(8.0);
+                                            let mut hidden = deck.cards()[i].is_hidden();
+                                            if ui
+                                                .checkbox(&mut hidden, "Hidden (skip during study)")
+                                                .changed()
+                                            {
+                                                deck.cards_mut()[i].set_hidden(hidden);
+                                                let _ =
+                                                    ec.multi_store.save_deck(deck, ec.deck_source);
+                                            }
 
                                             ui.add_space(8.0);
                                             ui.label("Tags:");


### PR DESCRIPTION
## Summary

Adds a per-card `hidden` boolean so individual cards can be excluded from study sessions without deleting them. The flag defaults to `false` and is omitted from TOML when unset, so existing decks deserialize unchanged. Hidden cards are filtered out of both the spaced-repetition due list and the random-study tag filter (and from the "X/Y cards match" count). The editor exposes a checkbox to toggle it and marks hidden cards in the collapsed card header.

## Test plan

ci