### PR TITLE
Add decks check command to compile every card and surface typst diagnostics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1301,6 +1301,7 @@ dependencies = [
  "clap",
  "cram_cli",
  "cram_core",
+ "cram_render",
  "cram_store",
  "cram_ui",
  "dirs",

--- a/crates/cram/Cargo.toml
+++ b/crates/cram/Cargo.toml
@@ -18,6 +18,7 @@ axoupdater.workspace = true
 clap.workspace = true
 cram_cli.workspace = true
 cram_core.workspace = true
+cram_render.workspace = true
 cram_store.workspace = true
 cram_ui.workspace = true
 dirs.workspace = true

--- a/crates/cram/src/commands/decks.rs
+++ b/crates/cram/src/commands/decks.rs
@@ -2,7 +2,9 @@ use std::path::PathBuf;
 
 use crate::settings::GlobalSettings;
 use cram_core::Deck;
+use cram_render::{CheckResult, CompileError};
 use cram_store::{MultiStore, SourceKind, Store, exchange};
+use owo_colors::OwoColorize;
 
 fn store(settings: &GlobalSettings) -> anyhow::Result<Store> {
     match &settings.decks_dir {
@@ -148,6 +150,89 @@ pub fn import(settings: &GlobalSettings, path: PathBuf) -> anyhow::Result<()> {
         deck.cards().len()
     );
     Ok(())
+}
+
+pub fn check(settings: &GlobalSettings, name: Option<String>) -> anyhow::Result<()> {
+    let ms = multi_store(settings)?;
+    let decks = ms.load_all_decks()?;
+    let filtered: Vec<_> = match &name {
+        Some(n) => decks.iter().filter(|(d, _)| d.name() == n).collect(),
+        None => decks.iter().collect(),
+    };
+    if filtered.is_empty() {
+        if let Some(n) = name {
+            anyhow::bail!("deck not found: {n}");
+        }
+        println!("No decks found.");
+        return Ok(());
+    }
+
+    let mut total_cards = 0usize;
+    let mut total_errors = 0usize;
+    let mut total_warnings = 0usize;
+    let mut cards_with_errors = 0usize;
+
+    for (deck, _) in &filtered {
+        println!("{} ({} cards)", deck.name().bold(), deck.cards().len());
+        for card in deck.cards() {
+            total_cards += 1;
+            let front = cram_render::check(card.front());
+            let back = cram_render::check(card.back());
+            let card_has_error = !front.errors.is_empty() || !back.errors.is_empty();
+            if card_has_error {
+                cards_with_errors += 1;
+            }
+            total_errors += front.errors.len() + back.errors.len();
+            total_warnings += front.warnings.len() + back.warnings.len();
+            print_card_diagnostics(card.id(), "front", &front);
+            print_card_diagnostics(card.id(), "back", &back);
+        }
+    }
+
+    println!();
+    println!(
+        "Checked {} card{} across {} deck{}: {} error{}, {} warning{}{}",
+        total_cards,
+        if total_cards == 1 { "" } else { "s" },
+        filtered.len(),
+        if filtered.len() == 1 { "" } else { "s" },
+        total_errors,
+        if total_errors == 1 { "" } else { "s" },
+        total_warnings,
+        if total_warnings == 1 { "" } else { "s" },
+        if cards_with_errors > 0 {
+            format!(" ({cards_with_errors} card(s) failed)")
+        } else {
+            String::new()
+        },
+    );
+
+    if total_errors > 0 {
+        anyhow::bail!("compile errors found");
+    }
+    Ok(())
+}
+
+fn print_card_diagnostics(card_id: impl std::fmt::Display, side: &str, result: &CheckResult) {
+    if result.is_clean() {
+        return;
+    }
+    let card_id = card_id.to_string();
+    for err in &result.errors {
+        print_diagnostic(&card_id, side, "error", err, true);
+    }
+    for warn in &result.warnings {
+        print_diagnostic(&card_id, side, "warning", warn, false);
+    }
+}
+
+fn print_diagnostic(card_id: &str, side: &str, level: &str, diag: &CompileError, is_error: bool) {
+    let head = if is_error {
+        format!("  {} card {card_id} ({side}):", level.red().bold())
+    } else {
+        format!("  {} card {card_id} ({side}):", level.yellow().bold())
+    };
+    println!("{head} {diag}");
 }
 
 pub fn sources(settings: &GlobalSettings) -> anyhow::Result<()> {

--- a/crates/cram/src/main.rs
+++ b/crates/cram/src/main.rs
@@ -65,6 +65,7 @@ fn run(cli: Cli, settings: &GlobalSettings) -> anyhow::Result<ExitStatus> {
             DecksCommand::Unlink { path } => commands::decks::unlink(settings, path)?,
             DecksCommand::Sources => commands::decks::sources(settings)?,
             DecksCommand::Sync => commands::sync::sync(settings)?,
+            DecksCommand::Check { name } => commands::decks::check(settings, name)?,
         },
         Some(Command::Self_ { command }) => match command {
             SelfCommand::Update { token, prerelease } => {

--- a/crates/cram/tests/it/decks.rs
+++ b/crates/cram/tests/it/decks.rs
@@ -15,6 +15,97 @@ fn decks_list_empty() {
 }
 
 #[test]
+fn decks_check_empty() {
+    let ctx = TestContext::new();
+    cram_snapshot!(ctx.filters(), ctx.command().args(["decks", "check"]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    No decks found.
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn decks_check_clean_deck() {
+    let ctx = TestContext::new();
+    let deck_path = ctx._root.path().join("decks").join("test.toml");
+    std::fs::create_dir_all(deck_path.parent().unwrap()).expect("create dir");
+    std::fs::write(
+        &deck_path,
+        r#"name = "test"
+description = ""
+created = "2026-03-02"
+preamble = ""
+
+[[cards]]
+id = "00000000-0000-0000-0000-000000000001"
+front = "Q1"
+back = "A1"
+"#,
+    )
+    .expect("write deck");
+
+    cram_snapshot!(ctx.filters(), ctx.command().args(["decks", "check"]), @r"
+    success: true
+    exit_code: 0
+    ----- stdout -----
+    test (1 cards)
+
+    Checked 1 card across 1 deck: 0 errors, 0 warnings
+
+    ----- stderr -----
+    ");
+}
+
+#[test]
+fn decks_check_reports_broken_card() {
+    let ctx = TestContext::new();
+    let deck_path = ctx._root.path().join("decks").join("broken.toml");
+    std::fs::create_dir_all(deck_path.parent().unwrap()).expect("create dir");
+    std::fs::write(
+        &deck_path,
+        r##"name = "broken"
+description = ""
+created = "2026-03-02"
+preamble = ""
+
+[[cards]]
+id = "00000000-0000-0000-0000-000000000001"
+front = "#unknown_func()"
+back = "ok"
+"##,
+    )
+    .expect("write deck");
+
+    let output = ctx
+        .command()
+        .args(["decks", "check"])
+        .output()
+        .expect("run");
+    assert!(!output.status.success(), "expected non-zero exit");
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let plain_stdout = regex::Regex::new(r"\x1b\[[0-9;]*m")
+        .expect("compile ansi regex")
+        .replace_all(&stdout, "");
+    assert!(
+        plain_stdout.contains("broken (1 cards)"),
+        "stdout: {plain_stdout}"
+    );
+    assert!(
+        plain_stdout.contains("error card 00000000-0000-0000-0000-000000000001 (front)"),
+        "stdout: {plain_stdout}"
+    );
+    assert!(
+        plain_stdout.contains("unknown variable: unknown_func"),
+        "stdout: {plain_stdout}"
+    );
+    assert!(stderr.contains("compile errors found"), "stderr: {stderr}");
+}
+
+#[test]
 fn decks_dir_prints_path() {
     let ctx = TestContext::new();
     cram_snapshot!(ctx.filters(), ctx.command().args(["decks", "dir"]), @"

--- a/crates/cram_cli/src/lib.rs
+++ b/crates/cram_cli/src/lib.rs
@@ -80,6 +80,12 @@ pub enum DecksCommand {
     Sources,
     /// Sync all linked sources (git pull)
     Sync,
+    /// Compile every card's Typst source and report errors and warnings
+    Check {
+        /// Only check the deck with this name (defaults to all decks)
+        #[arg(long)]
+        name: Option<String>,
+    },
 }
 
 #[derive(Subcommand)]

--- a/crates/cram_render/src/lib.rs
+++ b/crates/cram_render/src/lib.rs
@@ -3,11 +3,65 @@ mod world;
 
 pub use error::{CompileError, RenderError};
 
+use typst::diag::SourceDiagnostic;
 use typst::layout::PagedDocument;
 use world::CramWorld;
 
 /// Number of lines the internal preamble adds before the user's source.
 const PREAMBLE_LINES: usize = 2;
+
+/// Result of a compile-only check against a Typst source string.
+#[derive(Debug, Default, Clone)]
+pub struct CheckResult {
+    pub errors: Vec<CompileError>,
+    pub warnings: Vec<CompileError>,
+}
+
+impl CheckResult {
+    pub fn is_clean(&self) -> bool {
+        self.errors.is_empty() && self.warnings.is_empty()
+    }
+}
+
+/// Compile a Typst source string without rendering or encoding, returning
+/// any errors and warnings produced. Uses the same preamble as [`render`]
+/// so diagnostics line up with what the renderer would report.
+pub fn check(source: &str) -> CheckResult {
+    let world = CramWorld::new(source);
+    let result = typst::compile::<PagedDocument>(&world);
+    let main = world.main_source();
+    let errors = match result.output {
+        Ok(_) => Vec::new(),
+        Err(diags) => diags.iter().map(|d| diag_to_compile(d, main, 0)).collect(),
+    };
+    let warnings = result
+        .warnings
+        .iter()
+        .map(|d| diag_to_compile(d, main, 0))
+        .collect();
+    CheckResult { errors, warnings }
+}
+
+fn diag_to_compile(
+    diag: &SourceDiagnostic,
+    source: &typst::syntax::Source,
+    line_offset: usize,
+) -> CompileError {
+    let (line, column) = source
+        .range(diag.span)
+        .and_then(|range| source.lines().byte_to_line_column(range.start))
+        .map(|(l, c)| {
+            let user_line = l.saturating_sub(line_offset) + 1;
+            (Some(user_line), Some(c + 1))
+        })
+        .unwrap_or((None, None));
+    CompileError {
+        line,
+        column,
+        message: diag.message.to_string(),
+        hints: diag.hints.iter().map(|h| h.to_string()).collect(),
+    }
+}
 
 /// Render a Typst source string to PNG bytes at 2x pixel density.
 /// The page is auto-sized to the content (not A4).
@@ -47,22 +101,7 @@ pub fn render_with_width(
         let source = world.main_source();
         let errors = diagnostics
             .iter()
-            .map(|diag| {
-                let (line, column) = source
-                    .range(diag.span)
-                    .and_then(|range| source.lines().byte_to_line_column(range.start))
-                    .map(|(l, c)| {
-                        let user_line = l.saturating_sub(PREAMBLE_LINES) + 1;
-                        (Some(user_line), Some(c + 1))
-                    })
-                    .unwrap_or((None, None));
-                CompileError {
-                    line,
-                    column,
-                    message: diag.message.to_string(),
-                    hints: diag.hints.iter().map(|h| h.to_string()).collect(),
-                }
-            })
+            .map(|diag| diag_to_compile(diag, source, PREAMBLE_LINES))
             .collect();
         RenderError::Compile(errors)
     })?;
@@ -165,6 +204,28 @@ mod tests {
         let bytes = render_with_width("= Hello World", false, Some(200.0)).expect("render failed");
         assert!(!bytes.is_empty());
         assert_eq!(&bytes[..4], b"\x89PNG");
+    }
+
+    #[test]
+    fn check_clean_source_has_no_errors_or_warnings() {
+        let result = check("= Hello");
+        assert!(result.errors.is_empty(), "errors: {:?}", result.errors);
+        assert!(result.is_clean());
+    }
+
+    #[test]
+    fn check_reports_compile_errors() {
+        let result = check("#unknown_func()");
+        assert!(!result.errors.is_empty());
+        assert!(!result.is_clean());
+    }
+
+    #[test]
+    fn check_error_lines_match_user_source() {
+        let result = check("hello\n#let x = ");
+        let first = result.errors.first().expect("expected an error");
+        let line = first.line.expect("expected a line number");
+        assert!(line >= 1, "line should be in user source, got {line}");
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Adds `cram decks check` (with optional `--name`) which loads every deck from the primary store and any linked sources, runs each card's front and back through Typst's compiler, and prints any errors and warnings grouped by deck and card. Exits non-zero when any compile errors are found.

The shared diagnostic-resolution path was lifted into a `diag_to_compile` helper in `cram_render` and a new `check()` entry point that compiles without rendering or PNG encoding. `check()` does not wrap the source in the render preamble, so diagnostics already point at the user's source — `render_with_width` keeps using the preamble offset.

## Test plan

ci