### PR TITLE
Stop overwriting externally-edited deck files

### DIFF
--- a/crates/cram_store/src/lib.rs
+++ b/crates/cram_store/src/lib.rs
@@ -7,7 +7,7 @@ mod store;
 mod study_stats;
 
 pub use error::StoreError;
-pub use multi_store::{DeckSource, MultiStore, find_toml_files};
+pub use multi_store::{DeckSource, MultiStore, SaveOutcome, find_toml_files, serialize_deck};
 pub use sources::{SourceKind, Sources};
 pub use store::Store;
 pub use study_stats::{DeckSummary, SessionRecord, StudyStats};

--- a/crates/cram_store/src/multi_store.rs
+++ b/crates/cram_store/src/multi_store.rs
@@ -19,12 +19,32 @@ pub enum DeckSource {
     Linked(PathBuf),
 }
 
+/// Result of [`MultiStore::save_deck_if_changed`].
+#[derive(Debug)]
+pub enum SaveOutcome {
+    /// In-memory deck already matches the baseline (or on-disk file). Nothing written.
+    Unchanged,
+    /// File was written; the caller's baseline has been advanced.
+    Written,
+    /// File on disk has been modified outside cram since the last load/save.
+    /// The file was *not* overwritten; the caller should resolve the conflict.
+    Conflict { on_disk: String },
+}
+
+/// Serialize a deck to the pretty TOML form used by the on-disk store.
+pub fn serialize_deck(deck: &Deck) -> Result<String> {
+    Ok(toml::to_string_pretty(deck)?)
+}
+
 /// Cached entry for a single deck file, keyed by its path.
 #[derive(Clone)]
 struct CachedDeck {
     deck: Deck,
     source: DeckSource,
     modified: SystemTime,
+    /// Raw file content at the time of the last read. Used to seed the
+    /// caller's baseline for conflict-aware saves.
+    content: String,
 }
 
 /// Stores previously loaded decks keyed by file path, along with their
@@ -93,6 +113,53 @@ impl MultiStore {
         &self.config_dir
     }
 
+    /// Like [`Self::load_all_decks`] but additionally returns the raw on-disk
+    /// content for each deck, suitable for use as a baseline with
+    /// [`Self::save_deck_if_changed`].
+    pub fn load_all_decks_with_baseline(&self) -> Result<Vec<(Deck, DeckSource, String)>> {
+        Ok(self
+            .load_all_decks_inner()?
+            .into_iter()
+            .map(|e| (e.deck, e.source, e.content))
+            .collect())
+    }
+
+    fn load_all_decks_inner(&self) -> Result<Vec<CachedDeck>> {
+        let mut result = Vec::new();
+        let mut cache = self.cache.borrow_mut();
+        let mut seen_paths: Vec<PathBuf> = Vec::new();
+
+        for file_path in self.primary_toml_files() {
+            seen_paths.push(file_path.clone());
+            if let Some(entry) = cached_or_reload(&mut cache.entries, &file_path, DeckSource::Local)
+            {
+                result.push(entry);
+            }
+        }
+
+        for dir in &self.linked_folders {
+            for file_path in find_toml_files(dir) {
+                seen_paths.push(file_path.clone());
+                let source = DeckSource::Linked(file_path.clone());
+                if let Some(entry) = cached_or_reload(&mut cache.entries, &file_path, source) {
+                    result.push(entry);
+                }
+            }
+        }
+
+        for file_path in &self.linked_files {
+            seen_paths.push(file_path.clone());
+            let source = DeckSource::Linked(file_path.clone());
+            if let Some(entry) = cached_or_reload(&mut cache.entries, file_path, source) {
+                result.push(entry);
+            }
+        }
+
+        cache.entries.retain(|k, _| seen_paths.contains(k));
+
+        Ok(result)
+    }
+
     /// Load all decks from the primary store and all linked sources.
     ///
     /// Results are cached by file path and modification time. Only files whose
@@ -145,24 +212,75 @@ impl MultiStore {
         self.cache.borrow_mut().entries.clear();
     }
 
-    /// Save a deck back to its source location.
+    /// Save a deck back to its source location, overwriting unconditionally.
+    ///
+    /// Prefer [`Self::save_deck_if_changed`] in interactive contexts so external
+    /// edits aren't clobbered when cram has no pending changes.
     ///
     /// Invalidates the deck cache so the next `load_all_decks` picks up changes.
     pub fn save_deck(&self, deck: &Deck, source: &DeckSource) -> Result<()> {
-        let result = match source {
-            DeckSource::Local => self.primary.save_deck(deck),
+        let path = self.deck_target_path(deck, source)?;
+        let content = serialize_deck(deck)?;
+        std::fs::write(&path, content)?;
+        self.invalidate_cache();
+        Ok(())
+    }
+
+    /// Save a deck only if its serialized form differs from `baseline` (the
+    /// content last loaded/written by cram). Detects external edits that
+    /// would otherwise be silently overwritten.
+    ///
+    /// On `Written`, `baseline` is updated to the newly-persisted content.
+    /// On `Conflict`, the file is left untouched and the on-disk content is
+    /// returned so the caller can prompt the user.
+    pub fn save_deck_if_changed(
+        &self,
+        deck: &Deck,
+        source: &DeckSource,
+        baseline: &mut String,
+    ) -> Result<SaveOutcome> {
+        let current = serialize_deck(deck)?;
+        if current == *baseline {
+            return Ok(SaveOutcome::Unchanged);
+        }
+
+        let path = self.deck_target_path(deck, source)?;
+        let on_disk = std::fs::read_to_string(&path).ok();
+
+        if let Some(disk) = on_disk.as_deref() {
+            if disk == current {
+                *baseline = current;
+                return Ok(SaveOutcome::Unchanged);
+            }
+            if disk != baseline.as_str() {
+                return Ok(SaveOutcome::Conflict {
+                    on_disk: disk.to_string(),
+                });
+            }
+        }
+
+        std::fs::write(&path, &current)?;
+        *baseline = current;
+        self.invalidate_cache();
+        Ok(SaveOutcome::Written)
+    }
+
+    /// Resolve the on-disk path that `save_deck` would write to.
+    fn deck_target_path(&self, deck: &Deck, source: &DeckSource) -> Result<PathBuf> {
+        match source {
+            DeckSource::Local => Ok(self
+                .primary
+                .data_dir()
+                .join(format!("{}.toml", deck.name()))),
             DeckSource::Linked(path) => {
                 if path.extension().and_then(|e| e.to_str()) == Some("toml") {
-                    let content = toml::to_string_pretty(deck)?;
-                    Ok(std::fs::write(path, content)?)
+                    Ok(path.clone())
                 } else {
                     let store = Store::open(path.clone())?;
-                    store.save_deck(deck)
+                    Ok(store.data_dir().join(format!("{}.toml", deck.name())))
                 }
             }
-        };
-        self.invalidate_cache();
-        result
+        }
     }
 
     /// Delete a deck from whichever store it lives in.
@@ -301,13 +419,14 @@ fn cached_or_reload(
         return Some(cached.clone());
     }
 
-    match load_deck_from_file(path) {
-        Ok(deck) => {
+    match load_deck_from_file_with_content(path) {
+        Ok((deck, content)) => {
             let modified = mtime.unwrap_or(SystemTime::UNIX_EPOCH);
             let entry = CachedDeck {
                 deck,
                 source,
                 modified,
+                content,
             };
             entries.insert(path.to_path_buf(), entry.clone());
             Some(entry)
@@ -318,6 +437,12 @@ fn cached_or_reload(
             None
         }
     }
+}
+
+fn load_deck_from_file_with_content(path: &Path) -> Result<(Deck, String)> {
+    let content = std::fs::read_to_string(path)?;
+    let deck = toml::from_str(&content)?;
+    Ok((deck, content))
 }
 
 fn file_modified(path: &Path) -> Option<SystemTime> {
@@ -694,6 +819,73 @@ mod tests {
         let primary = Store::with_dir(primary_dir).expect("primary");
         let ms = MultiStore::new(primary, config_dir).expect("ms");
         assert!(ms.linked_folders.is_empty());
+    }
+
+    #[test]
+    fn save_if_changed_unchanged_for_identical_deck() {
+        let (ms, _dir) = temp_multi_store();
+        let deck = Deck::new("same", "");
+        ms.save_deck(&deck, &DeckSource::Local).expect("save");
+        let mut baseline = serialize_deck(&deck).expect("ser");
+
+        let outcome = ms
+            .save_deck_if_changed(&deck, &DeckSource::Local, &mut baseline)
+            .expect("save if changed");
+        assert!(matches!(outcome, SaveOutcome::Unchanged));
+    }
+
+    #[test]
+    fn save_if_changed_writes_when_deck_differs() {
+        let (ms, _dir) = temp_multi_store();
+        let mut deck = Deck::new("evolve", "");
+        ms.save_deck(&deck, &DeckSource::Local).expect("save");
+        let mut baseline = serialize_deck(&deck).expect("ser");
+
+        deck.preamble_mut().push_str("// changed");
+        let outcome = ms
+            .save_deck_if_changed(&deck, &DeckSource::Local, &mut baseline)
+            .expect("save if changed");
+        assert!(matches!(outcome, SaveOutcome::Written));
+        assert_eq!(baseline, serialize_deck(&deck).expect("ser"));
+    }
+
+    #[test]
+    fn save_if_changed_detects_external_modification() {
+        let (ms, _dir) = temp_multi_store();
+        let deck = Deck::new("conflict", "");
+        ms.save_deck(&deck, &DeckSource::Local).expect("save");
+        let mut baseline = serialize_deck(&deck).expect("ser");
+
+        let path = ms.primary().data_dir().join("conflict.toml");
+        std::fs::write(
+            &path,
+            "name = \"conflict\"\npreamble = \"externally edited\"\ncards = []\n",
+        )
+        .expect("external edit");
+
+        let mut modified = deck.clone();
+        modified.preamble_mut().push_str("// cram's own edit");
+        let outcome = ms
+            .save_deck_if_changed(&modified, &DeckSource::Local, &mut baseline)
+            .expect("save if changed");
+        match outcome {
+            SaveOutcome::Conflict { on_disk } => {
+                assert!(on_disk.contains("externally edited"));
+            }
+            other => panic!("expected Conflict, got {other:?}"),
+        }
+        let on_disk_after = std::fs::read_to_string(&path).expect("read");
+        assert!(on_disk_after.contains("externally edited"));
+    }
+
+    #[test]
+    fn load_all_decks_with_baseline_returns_raw_content() {
+        let (ms, _dir) = temp_multi_store();
+        ms.save_deck(&Deck::new("baseline", ""), &DeckSource::Local)
+            .expect("save");
+        let entries = ms.load_all_decks_with_baseline().expect("load");
+        assert_eq!(entries.len(), 1);
+        assert!(entries[0].2.contains("name = \"baseline\""));
     }
 
     #[test]

--- a/crates/cram_ui/src/app.rs
+++ b/crates/cram_ui/src/app.rs
@@ -5,7 +5,7 @@ use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
 use cram_core::Deck;
-use cram_store::{DeckSource, MultiStore, Store, StudyStats};
+use cram_store::{DeckSource, MultiStore, SaveOutcome, Store, StudyStats, serialize_deck};
 
 use crate::deck_detail::{DeckDetailAction, DeckDetailView};
 use crate::deck_list::DeckListAction;
@@ -67,9 +67,35 @@ pub enum StudyMode {
     SpacedRepetition,
 }
 
+/// A loaded deck together with its origin and the on-disk content baseline
+/// used to detect external edits when saving.
+pub struct DeckEntry {
+    pub deck: Deck,
+    pub source: DeckSource,
+    /// Serialized TOML matching what we last loaded from or wrote to disk.
+    pub baseline: String,
+    /// On-disk content captured when an external edit was detected; the UI
+    /// surfaces this so the user can resolve the conflict.
+    pub conflict: Option<String>,
+    /// Editor has pending in-memory changes that haven't been flushed to disk yet.
+    pub dirty: bool,
+}
+
+impl DeckEntry {
+    pub fn new(deck: Deck, source: DeckSource, baseline: String) -> Self {
+        Self {
+            deck,
+            source,
+            baseline,
+            conflict: None,
+            dirty: false,
+        }
+    }
+}
+
 pub struct CramApp {
     multi_store: MultiStore,
-    decks: Vec<(Deck, DeckSource)>,
+    decks: Vec<DeckEntry>,
     view: View,
     new_deck_name: String,
     texture_cache: TextureCache,
@@ -151,7 +177,12 @@ fn config_dir_for_store(store: &Store) -> PathBuf {
 impl CramApp {
     pub fn new(cc: &CreationContext) -> Self {
         let multi_store = build_multi_store();
-        let decks = multi_store.load_all_decks().unwrap_or_default();
+        let decks = multi_store
+            .load_all_decks_with_baseline()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(d, s, b)| DeckEntry::new(d, s, b))
+            .collect();
         let study_stats = StudyStats::load(multi_store.config_dir()).unwrap_or_default();
 
         let ui_state = UiState::load(multi_store.config_dir()).unwrap_or_default();
@@ -211,12 +242,81 @@ impl CramApp {
         if let Err(e) = self.multi_store.save_deck(&deck, &DeckSource::Local) {
             tracing::warn!("failed to save sample deck: {e}");
         } else {
-            self.decks.push((deck, DeckSource::Local));
+            let baseline = serialize_deck(&deck).unwrap_or_default();
+            self.decks
+                .push(DeckEntry::new(deck, DeckSource::Local, baseline));
         }
     }
 
     fn reload_decks(&mut self) {
-        self.decks = self.multi_store.load_all_decks().unwrap_or_default();
+        self.decks = self
+            .multi_store
+            .load_all_decks_with_baseline()
+            .unwrap_or_default()
+            .into_iter()
+            .map(|(d, s, b)| DeckEntry::new(d, s, b))
+            .collect();
+    }
+
+    /// Save the deck at `idx` to disk, honoring baselines so external edits
+    /// aren't clobbered. On conflict, the on-disk content is stashed on the
+    /// entry so the UI can prompt the user.
+    fn save_deck_at(&mut self, idx: usize) {
+        let Some(entry) = self.decks.get_mut(idx) else {
+            return;
+        };
+        match self
+            .multi_store
+            .save_deck_if_changed(&entry.deck, &entry.source, &mut entry.baseline)
+        {
+            Ok(SaveOutcome::Unchanged | SaveOutcome::Written) => {
+                entry.dirty = false;
+                entry.conflict = None;
+            }
+            Ok(SaveOutcome::Conflict { on_disk }) => {
+                entry.conflict = Some(on_disk);
+            }
+            Err(e) => {
+                tracing::warn!("failed to save deck '{}': {e}", entry.deck.name());
+            }
+        }
+    }
+
+    /// Force-write `idx` to disk, ignoring conflicts. Used when the user
+    /// explicitly chooses to overwrite externally-modified content.
+    fn force_save_deck_at(&mut self, idx: usize) {
+        let Some(entry) = self.decks.get_mut(idx) else {
+            return;
+        };
+        match self.multi_store.save_deck(&entry.deck, &entry.source) {
+            Ok(()) => {
+                entry.baseline = serialize_deck(&entry.deck).unwrap_or_default();
+                entry.dirty = false;
+                entry.conflict = None;
+            }
+            Err(e) => {
+                tracing::warn!("failed to force-save deck '{}': {e}", entry.deck.name());
+            }
+        }
+    }
+
+    /// Reload a single deck's in-memory state from disk, discarding any
+    /// unsaved in-memory changes.
+    fn reload_deck_at(&mut self, idx: usize) {
+        let Some(entry) = self.decks.get(idx) else {
+            return;
+        };
+        let name = entry.deck.name().to_string();
+        self.multi_store.invalidate_cache();
+        let fresh = self
+            .multi_store
+            .load_all_decks_with_baseline()
+            .unwrap_or_default()
+            .into_iter()
+            .find(|(d, _, _)| d.name() == name);
+        if let Some((deck, source, baseline)) = fresh {
+            self.decks[idx] = DeckEntry::new(deck, source, baseline);
+        }
     }
 
     /// Persist current UI state (theme, last deck) to `ui_state.toml`.
@@ -279,6 +379,14 @@ impl eframe::App for CramApp {
                     }
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         let prev = self.theme;
+                        if ui
+                            .selectable_label(false, egui::RichText::new("Sync").size(15.0))
+                            .on_hover_text("Reload decks from disk (picks up external edits)")
+                            .clicked()
+                        {
+                            self.reload_decks();
+                            self.texture_cache.clear();
+                        }
                         egui::ComboBox::from_id_salt("theme_picker")
                             .selected_text(self.theme.name())
                             .show_ui(ui, |ui| {
@@ -323,7 +431,7 @@ impl eframe::App for CramApp {
                     match view {
                         View::DeckList => {
                             let deck_refs: Vec<(&Deck, &DeckSource)> =
-                                self.decks.iter().map(|(d, s)| (d, s)).collect();
+                                self.decks.iter().map(|e| (&e.deck, &e.source)).collect();
                             if let Some(action) = DeckListView::show(
                                 ui,
                                 ctx,
@@ -342,8 +450,8 @@ impl eframe::App for CramApp {
                             if let Some(deck) = self
                                 .decks
                                 .iter()
-                                .find(|(d, _)| d.name() == deck_name)
-                                .map(|(d, _)| d.clone())
+                                .find(|e| e.deck.name() == deck_name)
+                                .map(|e| e.deck.clone())
                             {
                                 if let Some(action) = DeckDetailView::show(
                                     ui,
@@ -369,9 +477,9 @@ impl eframe::App for CramApp {
                             let deck_idx = self
                                 .decks
                                 .iter()
-                                .position(|(d, _)| d.name() == state.deck_name);
+                                .position(|e| e.deck.name() == state.deck_name);
                             if let Some(deck_idx) = deck_idx {
-                                let mut deck = self.decks[deck_idx].0.clone();
+                                let mut deck = self.decks[deck_idx].deck.clone();
                                 let session =
                                     self.study_session.get_or_insert_with(StudySession::new);
                                 let mut sc = StudyContext {
@@ -387,10 +495,8 @@ impl eframe::App for CramApp {
                                 };
                                 show_study(ui, ctx, &mut sc);
 
-                                self.decks[deck_idx].0 = deck;
-                                let _ = self
-                                    .multi_store
-                                    .save_deck(&self.decks[deck_idx].0, &self.decks[deck_idx].1);
+                                self.decks[deck_idx].deck = deck;
+                                self.save_deck_at(deck_idx);
 
                                 if let View::SessionSummary(ref summary) = self.view {
                                     self.study_stats.record_session(
@@ -416,45 +522,37 @@ impl eframe::App for CramApp {
                             deck_name,
                             card_index,
                         } => {
-                            let source = self
-                                .decks
-                                .iter()
-                                .find(|(d, _)| d.name() == deck_name)
-                                .map(|(_, s)| s.clone())
-                                .unwrap_or(DeckSource::Local);
-                            let mut deck_only: Vec<Deck> =
-                                self.decks.iter().map(|(d, _)| d.clone()).collect();
-                            let mut ec = EditorContext {
-                                decks: &mut deck_only,
-                                deck_name: &deck_name,
-                                card_index,
-                                multi_store: &self.multi_store,
-                                deck_source: &source,
-                                texture_cache: &mut self.texture_cache,
-                                preview_debounce: &mut self.preview_debounce,
-                                save_feedback: &mut self.save_feedback,
-                                tag_input: &mut self.tag_input,
-                            };
-                            let back = EditorView::show(ui, ctx, &mut ec);
-                            // Write modified decks back
-                            for (i, (deck, _src)) in self.decks.iter_mut().enumerate() {
-                                if i < deck_only.len() {
-                                    *deck = deck_only[i].clone();
-                                }
-                            }
-                            self.view = if back {
-                                View::DeckDetail {
-                                    deck_name: deck_name.clone(),
-                                }
-                            } else {
-                                View::Editor {
-                                    deck_name,
+                            let idx = self.decks.iter().position(|e| e.deck.name() == deck_name);
+                            if let Some(idx) = idx {
+                                let mut ec = EditorContext {
+                                    entry: &mut self.decks[idx],
                                     card_index,
+                                    texture_cache: &mut self.texture_cache,
+                                    preview_debounce: &mut self.preview_debounce,
+                                    save_feedback: &mut self.save_feedback,
+                                    tag_input: &mut self.tag_input,
+                                };
+                                let back = EditorView::show(ui, ctx, &mut ec);
+                                if self.decks[idx].dirty {
+                                    self.save_deck_at(idx);
                                 }
-                            };
+                                self.view = if back {
+                                    View::DeckDetail {
+                                        deck_name: deck_name.clone(),
+                                    }
+                                } else {
+                                    View::Editor {
+                                        deck_name,
+                                        card_index,
+                                    }
+                                };
+                            } else {
+                                self.view = View::DeckList;
+                            }
                         }
                         View::Search => {
-                            let deck_only: Vec<&Deck> = self.decks.iter().map(|(d, _)| d).collect();
+                            let deck_only: Vec<&Deck> =
+                                self.decks.iter().map(|e| &e.deck).collect();
                             if let Some((deck_name, card_index)) =
                                 SearchView::show(ui, &deck_only, &mut self.search_query)
                             {
@@ -531,7 +629,13 @@ impl eframe::App for CramApp {
                                                     self.error_message =
                                                         Some(format!("Failed to save: {e}"));
                                                 } else {
-                                                    self.decks.push((deck, DeckSource::Local));
+                                                    let baseline =
+                                                        serialize_deck(&deck).unwrap_or_default();
+                                                    self.decks.push(DeckEntry::new(
+                                                        deck,
+                                                        DeckSource::Local,
+                                                        baseline,
+                                                    ));
                                                     self.view = View::DeckList;
                                                     self.new_deck_name.clear();
                                                 }
@@ -552,13 +656,15 @@ impl eframe::App for CramApp {
             self.show_fullscreen_preview(ctx);
         }
 
+        self.show_conflict_modal(ctx);
+
         let current_deck = self.view.deck_name().map(str::to_string);
         if current_deck != prev_deck {
             if prev_was_editor {
                 let max_cards = self
                     .decks
                     .iter()
-                    .map(|(d, _)| d.cards().len())
+                    .map(|e| e.deck.cards().len())
                     .max()
                     .unwrap_or(0);
                 reset_card_collapse_states(ctx, max_cards);
@@ -593,6 +699,67 @@ impl CramApp {
             Err(e) => {
                 self.error_message = Some(format!("Failed to import: {e}"));
             }
+        }
+    }
+
+    /// Surfaces an "external edit detected" modal for the first deck whose
+    /// on-disk content diverged from cram's last-known baseline. The user can
+    /// reload from disk (discarding in-memory edits) or overwrite the file.
+    fn show_conflict_modal(&mut self, ctx: &Context) {
+        let Some(idx) = self.decks.iter().position(|e| e.conflict.is_some()) else {
+            return;
+        };
+        let entry = &self.decks[idx];
+        let name = entry.deck.name().to_string();
+        let on_disk = entry.conflict.clone().unwrap_or_default();
+
+        let mut reload = false;
+        let mut overwrite = false;
+        let mut dismiss = false;
+
+        egui::Window::new(format!("External changes: {name}"))
+            .anchor(egui::Align2::CENTER_CENTER, [0.0, 0.0])
+            .collapsible(false)
+            .resizable(false)
+            .show(ctx, |ui| {
+                ui.label(
+                    "This deck was modified on disk while cram had unsaved changes. \
+                     Choose how to resolve it:",
+                );
+                ui.add_space(8.0);
+                ui.collapsing("Show on-disk content", |ui| {
+                    egui::ScrollArea::vertical()
+                        .max_height(240.0)
+                        .show(ui, |ui| {
+                            ui.add(
+                                egui::TextEdit::multiline(&mut on_disk.as_str())
+                                    .font(egui::TextStyle::Monospace)
+                                    .desired_width(ui.available_width())
+                                    .interactive(false),
+                            );
+                        });
+                });
+                ui.add_space(8.0);
+                ui.horizontal(|ui| {
+                    if ui.button("Reload from disk").clicked() {
+                        reload = true;
+                    }
+                    if ui.button("Overwrite disk").clicked() {
+                        overwrite = true;
+                    }
+                    if ui.button("Cancel").clicked() {
+                        dismiss = true;
+                    }
+                });
+            });
+
+        if reload {
+            self.reload_deck_at(idx);
+            self.texture_cache.clear();
+        } else if overwrite {
+            self.force_save_deck_at(idx);
+        } else if dismiss {
+            self.decks[idx].conflict = None;
         }
     }
 

--- a/crates/cram_ui/src/editor.rs
+++ b/crates/cram_ui/src/editor.rs
@@ -1,11 +1,11 @@
 use std::collections::hash_map::DefaultHasher;
 use std::hash::{Hash, Hasher};
 
-use cram_core::{Card, Deck};
-use cram_store::{DeckSource, MultiStore};
+use cram_core::Card;
+use cram_store::DeckSource;
 use egui::{Context, Ui};
 
-use crate::app::PreviewDebounce;
+use crate::app::{DeckEntry, PreviewDebounce};
 use crate::highlight::typst_layout_job;
 use crate::style;
 use crate::texture_cache::{TextureCache, quantize_width};
@@ -14,11 +14,8 @@ use crate::texture_cache::{TextureCache, quantize_width};
 const ESTIMATED_CARD_BODY_HEIGHT: f32 = 500.0;
 
 pub struct EditorContext<'a> {
-    pub decks: &'a mut [Deck],
-    pub deck_name: &'a str,
+    pub entry: &'a mut DeckEntry,
     pub card_index: Option<usize>,
-    pub multi_store: &'a MultiStore,
-    pub deck_source: &'a DeckSource,
     pub texture_cache: &'a mut TextureCache,
     pub preview_debounce: &'a mut PreviewDebounce,
     pub save_feedback: &'a mut Option<std::time::Instant>,
@@ -30,10 +27,10 @@ pub struct EditorView;
 impl EditorView {
     /// Returns `true` if the user pressed the back button.
     pub fn show(ui: &mut Ui, ctx: &Context, ec: &mut EditorContext<'_>) -> bool {
-        let Some(deck) = ec.decks.iter_mut().find(|d| d.name() == ec.deck_name) else {
-            ui.label("Deck not found.");
-            return false;
-        };
+        let deck_name = ec.entry.deck.name().to_string();
+        let deck_source = ec.entry.source.clone();
+        let dirty = &mut ec.entry.dirty;
+        let deck = &mut ec.entry.deck;
 
         let mut back = false;
         let mut save_now = false;
@@ -47,8 +44,8 @@ impl EditorView {
                 {
                     back = true;
                 }
-                ui.heading(format!("Edit: {}", ec.deck_name));
-                if let DeckSource::Linked(path) = ec.deck_source {
+                ui.heading(format!("Edit: {}", &deck_name));
+                if let DeckSource::Linked(path) = &deck_source {
                     ui.label(
                         egui::RichText::new(shorten_home(path))
                             .small()
@@ -70,7 +67,7 @@ impl EditorView {
                             );
                         state.set_open(true);
                         state.store(ui.ctx());
-                        let _ = ec.multi_store.save_deck(deck, ec.deck_source);
+                        *dirty = true;
                     }
                     if ui
                         .selectable_label(false, egui::RichText::new("Save").size(15.0))
@@ -127,7 +124,7 @@ impl EditorView {
                         )
                         .changed()
                     {
-                        let _ = ec.multi_store.save_deck(deck, ec.deck_source);
+                        *dirty = true;
                         ec.texture_cache.clear();
                     }
                 });
@@ -257,8 +254,7 @@ impl EditorView {
                                                 .changed()
                                             {
                                                 deck.cards_mut()[i].set_hidden(hidden);
-                                                let _ =
-                                                    ec.multi_store.save_deck(deck, ec.deck_source);
+                                                *dirty = true;
                                             }
 
                                             ui.add_space(8.0);
@@ -284,9 +280,7 @@ impl EditorView {
                                                 }
                                                 if let Some(ti) = tag_to_remove {
                                                     deck.cards_mut()[i].tags_mut().remove(ti);
-                                                    let _ = ec
-                                                        .multi_store
-                                                        .save_deck(deck, ec.deck_source);
+                                                    *dirty = true;
                                                 }
                                             });
                                             let all_tags = deck.all_tags();
@@ -322,9 +316,7 @@ impl EditorView {
                                                             deck.cards_mut()[i]
                                                                 .tags_mut()
                                                                 .push(tag);
-                                                            let _ = ec
-                                                                .multi_store
-                                                                .save_deck(deck, ec.deck_source);
+                                                            *dirty = true;
                                                         }
                                                         buf.clear();
                                                         ui.memory_mut(|m| {
@@ -339,9 +331,7 @@ impl EditorView {
                                                     && !deck.cards()[i].has_tag(&trimmed)
                                                 {
                                                     deck.cards_mut()[i].tags_mut().push(trimmed);
-                                                    let _ = ec
-                                                        .multi_store
-                                                        .save_deck(deck, ec.deck_source);
+                                                    *dirty = true;
                                                 }
                                                 buf.clear();
                                             }
@@ -435,12 +425,12 @@ impl EditorView {
                 }
 
                 if save_now {
-                    let _ = ec.multi_store.save_deck(deck, ec.deck_source);
+                    *dirty = true;
                     *ec.save_feedback = Some(std::time::Instant::now());
                 }
                 if let Some(idx) = to_delete {
                     deck.cards_mut().remove(idx);
-                    let _ = ec.multi_store.save_deck(deck, ec.deck_source);
+                    *dirty = true;
                 }
             });
         });


### PR DESCRIPTION
Cram persisted decks on every editor keystroke and every frame in study mode, with no check for whether the in-memory state had actually changed. Editing a deck file outside cram while cram was open meant the next save would clobber those external edits.

Each loaded deck now carries a baseline (the TOML it was loaded from or last wrote). `MultiStore::save_deck_if_changed` skips the write when the serialized deck matches the baseline, and returns a `Conflict` outcome when disk diverged from the baseline without cram knowing — in that case the file is left alone and the UI shows a modal letting the user reload from disk or overwrite. A topbar `Sync` button does the same reload for all decks.

## Test plan

ci