### PR TITLE
Rework UI with shadcn-style theme and components

### DIFF
--- a/crates/cram_ui/src/app.rs
+++ b/crates/cram_ui/src/app.rs
@@ -187,7 +187,7 @@ impl CramApp {
 
         let ui_state = UiState::load(multi_store.config_dir()).unwrap_or_default();
         let theme = ui_state.theme.unwrap_or_default();
-        cc.egui_ctx.set_visuals(theme.visuals());
+        theme.apply(&cc.egui_ctx);
 
         let mut app = Self {
             multi_store,
@@ -345,21 +345,13 @@ impl eframe::App for CramApp {
     fn update(&mut self, ctx: &Context, _frame: &mut eframe::Frame) {
         let prev_was_editor = matches!(self.view, View::Editor { .. });
         let prev_deck = self.view.deck_name().map(str::to_string);
-        egui::TopBottomPanel::top("topbar")
-            .frame(
-                egui::Frame::new()
-                    .fill(ctx.style().visuals.panel_fill)
-                    .inner_margin(egui::Margin::symmetric(16, 10)),
-            )
+        let topbar_response = egui::TopBottomPanel::top("topbar")
+            .frame(crate::components::topbar_frame(self.theme.is_dark()))
             .show(ctx, |ui| {
                 ui.horizontal(|ui| {
-                    ui.spacing_mut().button_padding = egui::vec2(12.0, 6.0);
-                    egui::Frame::new()
-                        .inner_margin(egui::Margin::symmetric(0, 6))
-                        .show(ui, |ui| {
-                            ui.label(egui::RichText::new("Cram").strong().size(18.0));
-                        });
-                    ui.separator();
+                    ui.add_space(crate::components::SPACE_1);
+                    ui.label(egui::RichText::new("Cram").strong().size(18.0));
+                    ui.add_space(crate::components::SPACE_5);
                     let nav = [
                         ("Decks", View::DeckList),
                         ("Search", View::Search),
@@ -372,50 +364,58 @@ impl eframe::App for CramApp {
                         } else {
                             std::mem::discriminant(&self.view) == std::mem::discriminant(&target)
                         };
-                        let text = egui::RichText::new(label).size(15.0);
-                        if ui.selectable_label(active, text).clicked() {
+                        if crate::components::nav_tab(ui, label, active).clicked() {
                             self.view = target;
                         }
                     }
                     ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                         let prev = self.theme;
-                        if ui
-                            .selectable_label(false, egui::RichText::new("Sync").size(15.0))
+                        if crate::components::nav_tab(ui, "Sync", false)
                             .on_hover_text("Reload decks from disk (picks up external edits)")
                             .clicked()
                         {
                             self.reload_decks();
                             self.texture_cache.clear();
                         }
-                        egui::ComboBox::from_id_salt("theme_picker")
-                            .selected_text(self.theme.name())
-                            .show_ui(ui, |ui| {
-                                for t in Theme::ALL {
-                                    ui.selectable_value(&mut self.theme, t, t.name());
-                                }
-                            });
+                        let toggle_label = if self.theme.is_dark() { "☀" } else { "☾" };
+                        if crate::components::nav_tab(ui, toggle_label, false)
+                            .on_hover_text("Toggle light/dark theme")
+                            .clicked()
+                        {
+                            self.theme = self.theme.toggled();
+                        }
                         if self.theme != prev {
-                            ctx.set_visuals(self.theme.visuals());
+                            self.theme.apply(ctx);
                             self.texture_cache.clear();
                             self.save_ui_state();
                         }
                     });
                 });
             });
+        crate::components::paint_bottom_border(ctx, topbar_response.response.rect);
 
         if let Some(err) = &self.error_message.clone() {
-            let bg = if self.theme.is_dark() {
-                egui::Color32::from_rgb(80, 20, 20)
-            } else {
-                egui::Color32::from_rgb(254, 226, 226)
-            };
+            let palette = self.theme.palette();
+            let bg =
+                palette
+                    .destructive
+                    .gamma_multiply(if self.theme.is_dark() { 0.18 } else { 0.12 });
             egui::TopBottomPanel::bottom("errors")
-                .frame(egui::Frame::new().fill(bg).inner_margin(8.0))
+                .frame(
+                    egui::Frame::new()
+                        .fill(bg)
+                        .stroke(egui::Stroke::new(1.0, palette.destructive))
+                        .corner_radius(crate::components::RADIUS_MD)
+                        .inner_margin(egui::Margin::symmetric(
+                            crate::components::SPACE_4 as i8,
+                            crate::components::SPACE_3 as i8,
+                        )),
+                )
                 .show(ctx, |ui| {
                     ui.horizontal(|ui| {
-                        ui.colored_label(egui::Color32::RED, err);
+                        ui.label(egui::RichText::new(err).color(palette.destructive).strong());
                         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                            if ui.button("✕").clicked() {
+                            if ui.add(crate::components::ghost(ui, "✕")).clicked() {
                                 self.error_message = None;
                             }
                         });
@@ -597,7 +597,10 @@ impl eframe::App for CramApp {
                                         let secs = summary.elapsed_secs % 60;
                                         ui.label(format!("Time: {mins}m {secs}s"));
                                         ui.add_space(style::SECTION_SPACING);
-                                        if ui.add(style::accent_button("Back to Decks")).clicked() {
+                                        if ui
+                                            .add(crate::components::primary(ui, "Back to Decks"))
+                                            .clicked()
+                                        {
                                             self.view = View::DeckList;
                                         }
                                     });
@@ -609,16 +612,24 @@ impl eframe::App for CramApp {
                                 ui.add_space(80.0);
                                 style::card_frame(ui).show(ui, |ui| {
                                     ui.set_max_width(400.0);
-                                    ui.vertical_centered(|ui| {
+                                    ui.vertical(|ui| {
                                         ui.heading("New Deck");
+                                        ui.add_space(crate::components::SPACE_2);
+                                        ui.label(
+                                            egui::RichText::new("Name")
+                                                .color(self.theme.palette().muted_foreground),
+                                        );
+                                        ui.add_space(crate::components::SPACE_1);
+                                        crate::components::text_input(
+                                            ui,
+                                            &mut self.new_deck_name,
+                                            "e.g. Rust Basics",
+                                        );
                                         ui.add_space(style::SECTION_SPACING);
                                         ui.horizontal(|ui| {
-                                            ui.label("Name:");
-                                            ui.text_edit_singleline(&mut self.new_deck_name);
-                                        });
-                                        ui.add_space(style::ITEM_SPACING);
-                                        ui.horizontal(|ui| {
-                                            if ui.add(style::accent_button("Create")).clicked()
+                                            if ui
+                                                .add(crate::components::primary(ui, "Create"))
+                                                .clicked()
                                                 && !self.new_deck_name.is_empty()
                                             {
                                                 let deck = Deck::new(self.new_deck_name.trim(), "");
@@ -640,7 +651,10 @@ impl eframe::App for CramApp {
                                                     self.new_deck_name.clear();
                                                 }
                                             }
-                                            if ui.add(style::secondary_button("Cancel")).clicked() {
+                                            if ui
+                                                .add(crate::components::outline(ui, "Cancel"))
+                                                .clicked()
+                                            {
                                                 self.view = View::DeckList;
                                             }
                                         });
@@ -731,23 +745,33 @@ impl CramApp {
                     egui::ScrollArea::vertical()
                         .max_height(240.0)
                         .show(ui, |ui| {
-                            ui.add(
-                                egui::TextEdit::multiline(&mut on_disk.as_str())
-                                    .font(egui::TextStyle::Monospace)
-                                    .desired_width(ui.available_width())
-                                    .interactive(false),
-                            );
+                            crate::components::input_frame(ui).show(ui, |ui| {
+                                ui.add(
+                                    egui::TextEdit::multiline(&mut on_disk.as_str())
+                                        .font(egui::TextStyle::Monospace)
+                                        .desired_width(ui.available_width())
+                                        .frame(false)
+                                        .margin(egui::Margin::ZERO)
+                                        .interactive(false),
+                                );
+                            });
                         });
                 });
-                ui.add_space(8.0);
+                ui.add_space(crate::components::SPACE_3);
                 ui.horizontal(|ui| {
-                    if ui.button("Reload from disk").clicked() {
+                    if ui
+                        .add(crate::components::outline(ui, "Reload from disk"))
+                        .clicked()
+                    {
                         reload = true;
                     }
-                    if ui.button("Overwrite disk").clicked() {
+                    if ui
+                        .add(crate::components::destructive(ui, "Overwrite disk"))
+                        .clicked()
+                    {
                         overwrite = true;
                     }
-                    if ui.button("Cancel").clicked() {
+                    if ui.add(crate::components::ghost(ui, "Cancel")).clicked() {
                         dismiss = true;
                     }
                 });

--- a/crates/cram_ui/src/app.rs
+++ b/crates/cram_ui/src/app.rs
@@ -376,6 +376,8 @@ impl eframe::App for CramApp {
                         {
                             self.reload_decks();
                             self.texture_cache.clear();
+                            self.study_session = None;
+                            self.view = View::DeckList;
                         }
                         let toggle_label = if self.theme.is_dark() { "☀" } else { "☾" };
                         if crate::components::nav_tab(ui, toggle_label, false)
@@ -490,7 +492,7 @@ impl eframe::App for CramApp {
                                     texture_cache: &mut self.texture_cache,
                                     session,
                                     view: &mut self.view,
-                                    shuffled_indices: &state.shuffled_indices,
+                                    shuffled_indices: &mut state.shuffled_indices,
                                     study_mode: state.study_mode,
                                 };
                                 show_study(ui, ctx, &mut sc);

--- a/crates/cram_ui/src/components/badge.rs
+++ b/crates/cram_ui/src/components/badge.rs
@@ -1,0 +1,43 @@
+use egui::{Frame, Response, RichText, Stroke, Ui};
+
+use super::tokens;
+use crate::theme::Palette;
+
+#[derive(Clone, Copy)]
+pub enum BadgeVariant {
+    Default,
+    Secondary,
+    Outline,
+    Destructive,
+}
+
+/// shadcn-style badge: small pill with foreground text and a tinted background.
+pub fn badge(ui: &mut Ui, text: &str, variant: BadgeVariant) -> Response {
+    let p = if ui.visuals().dark_mode {
+        Palette::DARK
+    } else {
+        Palette::LIGHT
+    };
+    let (fill, fg, stroke) = match variant {
+        BadgeVariant::Default => (p.primary, p.primary_foreground, Stroke::NONE),
+        BadgeVariant::Secondary => (p.secondary, p.secondary_foreground, Stroke::NONE),
+        BadgeVariant::Outline => (
+            egui::Color32::TRANSPARENT,
+            p.foreground,
+            Stroke::new(1.0, p.border),
+        ),
+        BadgeVariant::Destructive => (p.destructive, p.destructive_foreground, Stroke::NONE),
+    };
+    Frame::new()
+        .fill(fill)
+        .stroke(stroke)
+        .corner_radius(tokens::RADIUS_SM)
+        .inner_margin(egui::Margin::symmetric(
+            tokens::SPACE_2 as i8,
+            (tokens::SPACE_1 * 0.5) as i8,
+        ))
+        .show(ui, |ui| {
+            ui.label(RichText::new(text).color(fg).size(12.0).strong());
+        })
+        .response
+}

--- a/crates/cram_ui/src/components/button.rs
+++ b/crates/cram_ui/src/components/button.rs
@@ -1,0 +1,76 @@
+use egui::{Button, Color32, RichText, Stroke, Vec2, vec2};
+
+use super::tokens;
+use crate::theme::Palette;
+
+const BUTTON_MIN_SIZE: Vec2 = vec2(72.0, tokens::CONTROL_HEIGHT);
+const BUTTON_MIN_SIZE_SM: Vec2 = vec2(56.0, tokens::CONTROL_HEIGHT_SM);
+
+/// shadcn `default` variant — solid primary background, contrasting text.
+pub fn primary_button(text: &str) -> Button<'_> {
+    Button::new(rich(text, Palette::DARK.primary_foreground))
+        .fill(Palette::DARK.primary)
+        .corner_radius(tokens::RADIUS_MD)
+        .min_size(BUTTON_MIN_SIZE)
+}
+
+/// Light-mode-aware primary builder. Egui doesn't expose a way to inspect
+/// theme inside a `Button<'_>`, so use this when you have a `Ui` handy.
+pub fn primary(ui: &egui::Ui, text: &str) -> Button<'static> {
+    let p = palette(ui);
+    Button::new(rich(text, p.primary_foreground))
+        .fill(p.primary)
+        .corner_radius(tokens::RADIUS_MD)
+        .min_size(BUTTON_MIN_SIZE)
+}
+
+/// shadcn `secondary` variant — muted surface with foreground text.
+pub fn secondary(ui: &egui::Ui, text: &str) -> Button<'static> {
+    let p = palette(ui);
+    Button::new(rich(text, p.secondary_foreground))
+        .fill(p.secondary)
+        .stroke(Stroke::NONE)
+        .corner_radius(tokens::RADIUS_MD)
+        .min_size(BUTTON_MIN_SIZE)
+}
+
+/// shadcn `outline` variant — transparent fill, border, foreground text.
+pub fn outline(ui: &egui::Ui, text: &str) -> Button<'static> {
+    let p = palette(ui);
+    Button::new(rich(text, p.foreground))
+        .fill(Color32::TRANSPARENT)
+        .stroke(Stroke::new(1.0, p.border))
+        .corner_radius(tokens::RADIUS_MD)
+        .min_size(BUTTON_MIN_SIZE)
+}
+
+/// shadcn `ghost` variant — transparent until hovered.
+pub fn ghost(ui: &egui::Ui, text: &str) -> Button<'static> {
+    let p = palette(ui);
+    Button::new(rich(text, p.foreground))
+        .fill(Color32::TRANSPARENT)
+        .stroke(Stroke::NONE)
+        .corner_radius(tokens::RADIUS_MD)
+        .min_size(BUTTON_MIN_SIZE_SM)
+}
+
+/// shadcn `destructive` variant — red surface, light text.
+pub fn destructive(ui: &egui::Ui, text: &str) -> Button<'static> {
+    let p = palette(ui);
+    Button::new(rich(text, p.destructive_foreground))
+        .fill(p.destructive)
+        .corner_radius(tokens::RADIUS_MD)
+        .min_size(BUTTON_MIN_SIZE)
+}
+
+fn rich(text: &str, color: Color32) -> RichText {
+    RichText::new(text).color(color).strong()
+}
+
+fn palette(ui: &egui::Ui) -> Palette {
+    if ui.visuals().dark_mode {
+        Palette::DARK
+    } else {
+        Palette::LIGHT
+    }
+}

--- a/crates/cram_ui/src/components/card.rs
+++ b/crates/cram_ui/src/components/card.rs
@@ -1,0 +1,42 @@
+use egui::{Frame, Shadow, Stroke, Ui};
+
+use super::tokens;
+use crate::theme::Palette;
+
+fn palette(ui: &Ui) -> Palette {
+    if ui.visuals().dark_mode {
+        Palette::DARK
+    } else {
+        Palette::LIGHT
+    }
+}
+
+/// shadcn-style card: raised surface, 1px border, generous padding, subtle shadow.
+pub fn card_frame(ui: &Ui) -> Frame {
+    let p = palette(ui);
+    Frame::new()
+        .fill(p.card)
+        .corner_radius(tokens::RADIUS_XL)
+        .inner_margin(tokens::CARD_PADDING)
+        .stroke(Stroke::new(1.0, p.border))
+        .shadow(card_shadow(ui))
+}
+
+/// Borderless surface used inside containers that already have a border.
+pub fn surface_frame(ui: &Ui) -> Frame {
+    let p = palette(ui);
+    Frame::new()
+        .fill(p.muted)
+        .corner_radius(tokens::RADIUS_MD)
+        .inner_margin(tokens::SPACE_4)
+}
+
+pub fn card_shadow(ui: &Ui) -> Shadow {
+    let alpha = if ui.visuals().dark_mode { 60 } else { 14 };
+    Shadow {
+        spread: 0,
+        blur: 12,
+        offset: [0, 2],
+        color: egui::Color32::from_black_alpha(alpha),
+    }
+}

--- a/crates/cram_ui/src/components/input.rs
+++ b/crates/cram_ui/src/components/input.rs
@@ -1,0 +1,75 @@
+use egui::{Frame, Margin, Response, Stroke, TextEdit, Ui, vec2};
+
+use super::tokens;
+use crate::theme::Palette;
+
+fn palette(ui: &Ui) -> Palette {
+    if ui.visuals().dark_mode {
+        Palette::DARK
+    } else {
+        Palette::LIGHT
+    }
+}
+
+/// shadcn-style single-line input: h-9, rounded-md, 1px border, transparent
+/// bg in dark mode (lighter than the card surface in light mode).
+pub fn text_input(ui: &mut Ui, value: &mut String, hint: &str) -> Response {
+    let p = palette(ui);
+    let inner = Frame::new()
+        .fill(p.input_bg)
+        .stroke(Stroke::new(1.0, p.border))
+        .corner_radius(tokens::RADIUS_MD)
+        .inner_margin(Margin::symmetric(tokens::SPACE_3 as i8, 0));
+    inner
+        .show(ui, |ui| {
+            let avail = ui.available_width();
+            ui.set_min_height(tokens::CONTROL_HEIGHT);
+            ui.add_sized(
+                vec2(avail, tokens::CONTROL_HEIGHT),
+                TextEdit::singleline(value)
+                    .hint_text(hint)
+                    .frame(false)
+                    .desired_width(avail)
+                    .margin(Margin::ZERO),
+            )
+        })
+        .inner
+}
+
+/// Frame matching the shadcn input style — use to wrap a custom [`TextEdit`]
+/// (e.g. one with a syntax-highlighting layouter) so it picks up the same
+/// 1px border, `RADIUS_MD`, and padding as the standard inputs.
+pub fn input_frame(ui: &Ui) -> Frame {
+    let p = palette(ui);
+    Frame::new()
+        .fill(p.input_bg)
+        .stroke(Stroke::new(1.0, p.border))
+        .corner_radius(tokens::RADIUS_MD)
+        .inner_margin(Margin::symmetric(
+            tokens::SPACE_3 as i8,
+            tokens::SPACE_2 as i8,
+        ))
+}
+
+/// shadcn-style multiline input. Min height ~ 5 lines.
+pub fn text_area(ui: &mut Ui, value: &mut String, hint: &str, rows: usize) -> Response {
+    let p = palette(ui);
+    Frame::new()
+        .fill(p.input_bg)
+        .stroke(Stroke::new(1.0, p.border))
+        .corner_radius(tokens::RADIUS_MD)
+        .inner_margin(Margin::symmetric(
+            tokens::SPACE_3 as i8,
+            tokens::SPACE_2 as i8,
+        ))
+        .show(ui, |ui| {
+            ui.add(
+                TextEdit::multiline(value)
+                    .hint_text(hint)
+                    .frame(false)
+                    .desired_width(ui.available_width())
+                    .desired_rows(rows),
+            )
+        })
+        .inner
+}

--- a/crates/cram_ui/src/components/mod.rs
+++ b/crates/cram_ui/src/components/mod.rs
@@ -1,0 +1,29 @@
+//! shadcn-inspired UI primitives for egui.
+//!
+//! Each submodule mirrors a shadcn component family. Compose them like you
+//! would shadcn in React: a card containing inputs and buttons, badges for
+//! status, separators between sections.
+#![expect(
+    dead_code,
+    unused_imports,
+    reason = "intentional component-library surface — variants are exposed even when no caller uses them yet"
+)]
+
+pub mod badge;
+pub mod button;
+pub mod card;
+pub mod input;
+pub mod nav;
+pub mod separator;
+pub mod tokens;
+
+pub use badge::{BadgeVariant, badge};
+pub use button::{destructive, ghost, outline, primary, secondary};
+pub use card::{card_frame, surface_frame};
+pub use input::{input_frame, text_area, text_input};
+pub use nav::{nav_tab, paint_bottom_border, topbar_frame};
+pub use separator::separator;
+pub use tokens::{
+    CARD_PADDING, CONTENT_PADDING, CONTROL_HEIGHT, ITEM_SPACING, RADIUS_LG, RADIUS_MD, RADIUS_SM,
+    RADIUS_XL, SECTION_SPACING, SPACE_1, SPACE_2, SPACE_3, SPACE_4, SPACE_5, SPACE_6, SPACE_8,
+};

--- a/crates/cram_ui/src/components/nav.rs
+++ b/crates/cram_ui/src/components/nav.rs
@@ -1,0 +1,94 @@
+use egui::{
+    Align2, Color32, CornerRadius, FontId, Frame, Margin, Response, Sense, Stroke, TextStyle, Ui,
+    vec2,
+};
+
+use super::tokens;
+use crate::theme::Palette;
+
+fn palette(ui: &Ui) -> Palette {
+    if ui.visuals().dark_mode {
+        Palette::DARK
+    } else {
+        Palette::LIGHT
+    }
+}
+
+/// shadcn-style top app bar: panel background, 20px horizontal / 12px
+/// vertical padding. Pass as `frame` to a [`egui::TopBottomPanel`]. Use
+/// [`paint_bottom_border`] after the panel closes to render the hairline
+/// divider beneath it.
+pub fn topbar_frame(dark: bool) -> Frame {
+    let p = if dark { Palette::DARK } else { Palette::LIGHT };
+    Frame::new()
+        .fill(p.background)
+        .inner_margin(Margin::symmetric(
+            tokens::SPACE_5 as i8,
+            tokens::SPACE_3 as i8,
+        ))
+        .stroke(Stroke::NONE)
+}
+
+/// Paint a 1px divider along the bottom of `rect` in the theme border color.
+pub fn paint_bottom_border(ctx: &egui::Context, rect: egui::Rect) {
+    let dark = ctx.style().visuals.dark_mode;
+    let p = if dark { Palette::DARK } else { Palette::LIGHT };
+    let painter = ctx.layer_painter(egui::LayerId::new(
+        egui::Order::Foreground,
+        egui::Id::new("__topbar_border"),
+    ));
+    painter.hline(
+        rect.x_range(),
+        rect.bottom() - 0.5,
+        Stroke::new(1.0, p.border),
+    );
+}
+
+/// shadcn navigation-menu-style tab: foreground/muted text, accent-tinted
+/// background when hovered, and a stronger accent when active.
+pub fn nav_tab(ui: &mut Ui, label: &str, active: bool) -> Response {
+    let p = palette(ui);
+    let font_id = ui
+        .style()
+        .text_styles
+        .get(&TextStyle::Button)
+        .cloned()
+        .unwrap_or_else(|| FontId::proportional(14.0));
+
+    let padding = vec2(tokens::SPACE_3, tokens::SPACE_2);
+    let text_color = if active {
+        p.foreground
+    } else {
+        p.muted_foreground
+    };
+    let galley = ui
+        .painter()
+        .layout_no_wrap(label.to_owned(), font_id.clone(), text_color);
+    let size = galley.size() + 2.0 * padding;
+    let (rect, response) = ui.allocate_exact_size(size, Sense::click());
+
+    let bg = if active {
+        p.accent
+    } else if response.hovered() {
+        p.muted
+    } else {
+        Color32::TRANSPARENT
+    };
+    if bg != Color32::TRANSPARENT {
+        ui.painter()
+            .rect_filled(rect, CornerRadius::same(tokens::RADIUS_MD as u8), bg);
+    }
+    let hover_color = if response.hovered() && !active {
+        p.foreground
+    } else {
+        text_color
+    };
+    ui.painter().text(
+        rect.center(),
+        Align2::CENTER_CENTER,
+        label,
+        font_id,
+        hover_color,
+    );
+    response
+}

--- a/crates/cram_ui/src/components/separator.rs
+++ b/crates/cram_ui/src/components/separator.rs
@@ -1,0 +1,16 @@
+use egui::Ui;
+
+use crate::theme::Palette;
+
+/// shadcn-style separator: 1px line in the border color.
+pub fn separator(ui: &mut Ui) {
+    let p = if ui.visuals().dark_mode {
+        Palette::DARK
+    } else {
+        Palette::LIGHT
+    };
+    let available = ui.available_width();
+    let (rect, _) = ui.allocate_exact_size(egui::vec2(available, 1.0), egui::Sense::hover());
+    ui.painter()
+        .hline(rect.x_range(), rect.center().y, (1.0, p.border));
+}

--- a/crates/cram_ui/src/components/tokens.rs
+++ b/crates/cram_ui/src/components/tokens.rs
@@ -1,0 +1,34 @@
+//! Design tokens mirroring shadcn's defaults.
+//!
+//! Spacing follows Tailwind's 4px scale (SPACE_N = N * 4px).
+
+pub const SPACE_1: f32 = 4.0;
+pub const SPACE_2: f32 = 8.0;
+pub const SPACE_3: f32 = 12.0;
+pub const SPACE_4: f32 = 16.0;
+pub const SPACE_5: f32 = 20.0;
+pub const SPACE_6: f32 = 24.0;
+pub const SPACE_8: f32 = 32.0;
+
+/// Inner padding inside cards.
+pub const CARD_PADDING: f32 = SPACE_6;
+/// Outer page padding inside the central panel.
+pub const CONTENT_PADDING: f32 = SPACE_6;
+/// Gap between major sections.
+pub const SECTION_SPACING: f32 = SPACE_5;
+/// Gap between related items in a list/stack.
+pub const ITEM_SPACING: f32 = SPACE_3;
+
+/// shadcn `--radius-sm` ≈ 4px.
+pub const RADIUS_SM: f32 = 4.0;
+/// shadcn `--radius-md` ≈ 6px. Used for buttons, inputs, badges.
+pub const RADIUS_MD: f32 = 6.0;
+/// shadcn `--radius-lg` ≈ 8px.
+pub const RADIUS_LG: f32 = 8.0;
+/// shadcn `--radius-xl` ≈ 12px. Used for cards and dialogs.
+pub const RADIUS_XL: f32 = 12.0;
+
+/// Default control (button/input) height — shadcn h-9.
+pub const CONTROL_HEIGHT: f32 = 36.0;
+/// Small control height — shadcn h-8.
+pub const CONTROL_HEIGHT_SM: f32 = 32.0;

--- a/crates/cram_ui/src/deck_detail.rs
+++ b/crates/cram_ui/src/deck_detail.rs
@@ -45,11 +45,14 @@ impl DeckDetailView {
                     ));
                     ui.add_space(8.0);
                     ui.horizontal(|ui| {
-                        if ui.add(style::destructive_button("Delete")).clicked() {
+                        if ui
+                            .add(crate::components::destructive(ui, "Delete"))
+                            .clicked()
+                        {
                             action = Some(DeckDetailAction::Delete(deck_name));
                             *confirm_delete = None;
                         }
-                        if ui.add(style::secondary_button("Cancel")).clicked() {
+                        if ui.add(crate::components::outline(ui, "Cancel")).clicked() {
                             *confirm_delete = None;
                         }
                     });
@@ -66,7 +69,10 @@ impl DeckDetailView {
                 ui.heading(deck.name());
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
                     ui.spacing_mut().button_padding = egui::vec2(12.0, 6.0);
-                    if ui.add(style::destructive_button("Delete")).clicked() {
+                    if ui
+                        .add(crate::components::destructive(ui, "Delete"))
+                        .clicked()
+                    {
                         *confirm_delete = Some(deck.name().to_string());
                     }
                     if ui

--- a/crates/cram_ui/src/deck_list.rs
+++ b/crates/cram_ui/src/deck_list.rs
@@ -59,7 +59,10 @@ impl DeckListView {
                     ui.add_space(8.0);
                     ui.label("Create your first deck to start studying!");
                     ui.add_space(16.0);
-                    if ui.add(style::accent_button("＋ Create Deck")).clicked() {
+                    if ui
+                        .add(crate::components::primary(ui, "＋ Create Deck"))
+                        .clicked()
+                    {
                         *new_deck_name = String::new();
                         *view = View::NewDeck;
                     }

--- a/crates/cram_ui/src/editor.rs
+++ b/crates/cram_ui/src/editor.rs
@@ -114,16 +114,21 @@ impl EditorView {
                             job.wrap.max_width = wrap_width;
                             ui.fonts_mut(|f| f.layout_job(job))
                         };
-                    if ui
-                        .add(
-                            egui::TextEdit::multiline(deck.preamble_mut())
-                                .font(egui::TextStyle::Monospace)
-                                .desired_rows(3)
-                                .desired_width(ui.available_width())
-                                .layouter(&mut preamble_layouter),
-                        )
-                        .changed()
-                    {
+                    let changed = crate::components::input_frame(ui)
+                        .show(ui, |ui| {
+                            ui.add(
+                                egui::TextEdit::multiline(deck.preamble_mut())
+                                    .font(egui::TextStyle::Monospace)
+                                    .desired_rows(3)
+                                    .desired_width(ui.available_width())
+                                    .frame(false)
+                                    .margin(egui::Margin::ZERO)
+                                    .layouter(&mut preamble_layouter),
+                            )
+                            .changed()
+                        })
+                        .inner;
+                    if changed {
                         *dirty = true;
                         ec.texture_cache.clear();
                     }
@@ -173,7 +178,7 @@ impl EditorView {
                                             let header_btn = egui::vec2(80.0, 28.0);
                                             if ui
                                                 .add(
-                                                    style::destructive_button("Delete")
+                                                    crate::components::destructive(ui, "Delete")
                                                         .min_size(header_btn),
                                                 )
                                                 .clicked()
@@ -218,15 +223,19 @@ impl EditorView {
                                                 ui.fonts_mut(|f| f.layout_job(job))
                                             };
                                             ui.label("Front (Typst):");
-                                            ui.add(
-                                                egui::TextEdit::multiline(
-                                                    deck.cards_mut()[i].front_mut(),
-                                                )
-                                                .font(egui::TextStyle::Monospace)
-                                                .desired_rows(5)
-                                                .desired_width(col_w)
-                                                .layouter(&mut front_layouter),
-                                            );
+                                            crate::components::input_frame(ui).show(ui, |ui| {
+                                                ui.add(
+                                                    egui::TextEdit::multiline(
+                                                        deck.cards_mut()[i].front_mut(),
+                                                    )
+                                                    .font(egui::TextStyle::Monospace)
+                                                    .desired_rows(5)
+                                                    .desired_width(col_w)
+                                                    .frame(false)
+                                                    .margin(egui::Margin::ZERO)
+                                                    .layouter(&mut front_layouter),
+                                                );
+                                            });
                                             ui.add_space(4.0);
                                             let mut back_layouter = |ui: &egui::Ui,
                                                                      text: &dyn egui::TextBuffer,
@@ -237,15 +246,19 @@ impl EditorView {
                                                 ui.fonts_mut(|f| f.layout_job(job))
                                             };
                                             ui.label("Back (Typst):");
-                                            ui.add(
-                                                egui::TextEdit::multiline(
-                                                    deck.cards_mut()[i].back_mut(),
-                                                )
-                                                .font(egui::TextStyle::Monospace)
-                                                .desired_rows(5)
-                                                .desired_width(col_w)
-                                                .layouter(&mut back_layouter),
-                                            );
+                                            crate::components::input_frame(ui).show(ui, |ui| {
+                                                ui.add(
+                                                    egui::TextEdit::multiline(
+                                                        deck.cards_mut()[i].back_mut(),
+                                                    )
+                                                    .font(egui::TextStyle::Monospace)
+                                                    .desired_rows(5)
+                                                    .desired_width(col_w)
+                                                    .frame(false)
+                                                    .margin(egui::Margin::ZERO)
+                                                    .layouter(&mut back_layouter),
+                                                );
+                                            });
 
                                             ui.add_space(8.0);
                                             let mut hidden = deck.cards()[i].is_hidden();

--- a/crates/cram_ui/src/lib.rs
+++ b/crates/cram_ui/src/lib.rs
@@ -1,4 +1,5 @@
 mod app;
+mod components;
 mod deck_detail;
 mod deck_list;
 mod editor;

--- a/crates/cram_ui/src/search.rs
+++ b/crates/cram_ui/src/search.rs
@@ -15,10 +15,7 @@ impl SearchView {
             ui.heading("Search Cards");
             ui.add_space(12.0);
 
-            ui.horizontal(|ui| {
-                ui.label("Query:");
-                ui.text_edit_singleline(query);
-            });
+            crate::components::text_input(ui, query, "Search cards across all decks…");
             ui.add_space(12.0);
 
             if query.trim().is_empty() {

--- a/crates/cram_ui/src/sources.rs
+++ b/crates/cram_ui/src/sources.rs
@@ -409,7 +409,10 @@ fn show_source_entry(
                 });
 
                 ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
-                    if ui.add(style::destructive_button("Unlink")).clicked() {
+                    if ui
+                        .add(crate::components::destructive(ui, "Unlink"))
+                        .clicked()
+                    {
                         *unlink_path = Some(entry.path.clone());
                     }
                 });

--- a/crates/cram_ui/src/study.rs
+++ b/crates/cram_ui/src/study.rs
@@ -217,7 +217,7 @@ fn show_card(ui: &mut Ui, render_result: &Result<TextureHandle, String>, card_so
 
 fn show_reveal_button(ui: &mut Ui, revealed: &mut bool) {
     ui.vertical_centered(|ui| {
-        let btn = style::accent_button("Show Answer  [Space / Right]")
+        let btn = crate::components::primary(ui, "Show Answer  [Space / Right]")
             .min_size(egui::vec2(240.0, 44.0))
             .corner_radius(8.0);
         if ui.add(btn).clicked()
@@ -230,7 +230,7 @@ fn show_reveal_button(ui: &mut Ui, revealed: &mut bool) {
 
 fn show_random_next(ui: &mut Ui, sc: &mut StudyContext<'_>, total: usize) {
     ui.vertical_centered(|ui| {
-        let btn = style::accent_button("Next  [Space / Right]")
+        let btn = crate::components::primary(ui, "Next  [Space / Right]")
             .min_size(egui::vec2(240.0, 44.0))
             .corner_radius(8.0);
         if ui.add(btn).clicked()

--- a/crates/cram_ui/src/study.rs
+++ b/crates/cram_ui/src/study.rs
@@ -47,8 +47,9 @@ pub struct StudyContext<'a> {
     pub session: &'a mut StudySession,
     /// Current application view; mutated on navigation (Escape, session end).
     pub view: &'a mut View,
-    /// Card indices in the order they will be presented.
-    pub shuffled_indices: &'a [usize],
+    /// Card indices in the order they will be presented. Mutable so that
+    /// deleting the current card can remove its entry and shift higher indices.
+    pub shuffled_indices: &'a mut Vec<usize>,
     /// Whether this is a random or spaced-repetition session.
     pub study_mode: StudyMode,
 }
@@ -78,6 +79,13 @@ pub fn show_study(ui: &mut Ui, ctx: &Context, sc: &mut StudyContext<'_>) {
     let current_idx = (*sc.card_index).min(total.saturating_sub(1));
     let card_pos = sc.shuffled_indices[current_idx];
 
+    if card_pos >= sc.deck.cards().len() {
+        *sc.view = View::DeckDetail {
+            deck_name: sc.deck_name.to_string(),
+        };
+        return;
+    }
+
     let params = RenderParams {
         dark_mode: ui.visuals().dark_mode,
         quantized: quantize_width(ui.available_width() - 50.0),
@@ -105,8 +113,19 @@ pub fn show_study(ui: &mut Ui, ctx: &Context, sc: &mut StudyContext<'_>) {
         Some(params.width_pt),
     );
 
+    let mut delete_requested = false;
+    let mut edit_requested = false;
+
     ui.vertical(|ui| {
-        show_header(ui, sc.deck_name, sc.study_mode, current_idx, total);
+        show_header(
+            ui,
+            sc.deck_name,
+            sc.study_mode,
+            current_idx,
+            total,
+            &mut edit_requested,
+            &mut delete_requested,
+        );
 
         ui.separator();
         ui.add_space(24.0);
@@ -126,6 +145,15 @@ pub fn show_study(ui: &mut Ui, ctx: &Context, sc: &mut StudyContext<'_>) {
             }
         }
     });
+
+    if edit_requested {
+        *sc.view = View::Editor {
+            deck_name: sc.deck_name.to_string(),
+            card_index: Some(card_pos),
+        };
+    } else if delete_requested {
+        delete_current_card(sc, card_pos, current_idx);
+    }
 }
 
 /// Builds the Typst source for a card, combining the deck preamble with
@@ -176,6 +204,8 @@ fn show_header(
     study_mode: StudyMode,
     current_idx: usize,
     total: usize,
+    edit_requested: &mut bool,
+    delete_requested: &mut bool,
 ) {
     let progress = format!("{}/{}", current_idx + 1, total);
     let mode_label = match study_mode {
@@ -192,12 +222,25 @@ fn show_header(
         );
         ui.with_layout(egui::Layout::right_to_left(egui::Align::Center), |ui| {
             ui.label(&progress);
+            let header_btn = egui::vec2(70.0, 24.0);
+            if ui
+                .add(crate::components::destructive(ui, "Delete").min_size(header_btn))
+                .clicked()
+            {
+                *delete_requested = true;
+            }
+            if ui
+                .add(crate::components::outline(ui, "Edit").min_size(header_btn))
+                .clicked()
+            {
+                *edit_requested = true;
+            }
         });
     });
 
     #[expect(clippy::cast_precision_loss)]
     let fraction = (current_idx + 1) as f32 / total as f32;
-    ui.add(egui::ProgressBar::new(fraction).text(&progress));
+    ui.add(egui::ProgressBar::new(fraction));
 }
 
 fn show_card(ui: &mut Ui, render_result: &Result<TextureHandle, String>, card_source: &str) {
@@ -298,6 +341,31 @@ fn show_rating_buttons(ui: &mut Ui, sc: &mut StudyContext<'_>, card_pos: usize, 
             }
         });
     });
+}
+
+/// Removes the current card from the deck and from the shuffled order,
+/// shifting later indices down by one. Ends the session if no cards remain.
+fn delete_current_card(sc: &mut StudyContext<'_>, card_pos: usize, current_idx: usize) {
+    sc.deck.cards_mut().remove(card_pos);
+    sc.shuffled_indices.remove(current_idx);
+    for idx in sc.shuffled_indices.iter_mut() {
+        if *idx > card_pos {
+            *idx -= 1;
+        }
+    }
+
+    let total = sc.shuffled_indices.len();
+    if total == 0 {
+        let elapsed = sc.session.start.elapsed().as_secs();
+        *sc.view = View::SessionSummary(SessionSummaryState {
+            deck_name: sc.deck_name.to_string(),
+            cards_reviewed: sc.session.reviewed,
+            elapsed_secs: elapsed,
+        });
+    } else if *sc.card_index >= total {
+        *sc.card_index = total - 1;
+    }
+    *sc.revealed = false;
 }
 
 /// Moves to the next card or ends the session if all cards are done.

--- a/crates/cram_ui/src/style.rs
+++ b/crates/cram_ui/src/style.rs
@@ -1,57 +1,20 @@
-use egui::{Color32, Shadow, Stroke, Ui};
+//! Compatibility shim re-exporting the most-used `components` items under
+//! the older `style::` name. New code should reach for `crate::components`
+//! directly; this module exists to keep the diff manageable while the UI
+//! migrates over.
 
-pub const CARD_RADIUS: f32 = 10.0;
-pub const BUTTON_RADIUS: f32 = 8.0;
-pub const CARD_MARGIN: f32 = 20.0;
-pub const ACCENT: Color32 = Color32::from_rgb(59, 130, 246);
-pub const DESTRUCTIVE: Color32 = Color32::from_rgb(220, 50, 50);
-pub const CONTENT_PADDING: f32 = 24.0;
-pub const SECTION_SPACING: f32 = 20.0;
-pub const ITEM_SPACING: f32 = 12.0;
+use egui::{Color32, Frame, Ui};
 
-pub fn card_shadow() -> Shadow {
-    Shadow {
-        spread: 0,
-        blur: 8,
-        offset: [0, 2],
-        color: Color32::from_black_alpha(20),
-    }
-}
+pub use crate::components::tokens::{
+    CARD_PADDING as CARD_MARGIN, CONTENT_PADDING, ITEM_SPACING, SECTION_SPACING,
+};
 
-/// Standard card frame used across all views.
-pub fn card_frame(ui: &Ui) -> egui::Frame {
-    egui::Frame::new()
-        .fill(ui.visuals().faint_bg_color)
-        .corner_radius(CARD_RADIUS)
-        .inner_margin(CARD_MARGIN)
-        .shadow(card_shadow())
-        .stroke(Stroke::new(
-            1.0,
-            ui.visuals().widgets.noninteractive.bg_stroke.color,
-        ))
-}
+/// Brand accent used for foreground highlights (saved chips, matched terms).
+/// shadcn's neutral palette has no fixed accent hue, so we pick blue-500 —
+/// the same shade used by shadcn's default chart-1 and focus rings in
+/// non-neutral themes.
+pub const ACCENT: Color32 = Color32::from_rgb(0x3B, 0x82, 0xF6);
 
-const BUTTON_MIN_SIZE: egui::Vec2 = egui::vec2(64.0, 34.0);
-
-/// Primary action button with accent fill and white text.
-pub fn accent_button(text: &str) -> egui::Button<'_> {
-    egui::Button::new(egui::RichText::new(text).color(Color32::WHITE))
-        .fill(ACCENT)
-        .corner_radius(BUTTON_RADIUS)
-        .min_size(BUTTON_MIN_SIZE)
-}
-
-/// Secondary action button with consistent radius and min size.
-pub fn secondary_button(text: &str) -> egui::Button<'_> {
-    egui::Button::new(text)
-        .corner_radius(BUTTON_RADIUS)
-        .min_size(BUTTON_MIN_SIZE)
-}
-
-/// Destructive action button with red fill and white text.
-pub fn destructive_button(text: &str) -> egui::Button<'_> {
-    egui::Button::new(egui::RichText::new(text).color(Color32::WHITE))
-        .fill(DESTRUCTIVE)
-        .corner_radius(BUTTON_RADIUS)
-        .min_size(BUTTON_MIN_SIZE)
+pub fn card_frame(ui: &Ui) -> Frame {
+    crate::components::card_frame(ui)
 }

--- a/crates/cram_ui/src/theme.rs
+++ b/crates/cram_ui/src/theme.rs
@@ -1,5 +1,7 @@
-use egui::{Color32, Stroke, Visuals};
+use egui::{Color32, CornerRadius, Margin, Shadow, Stroke, Visuals, style::WidgetVisuals};
 use serde::{Deserialize, Serialize};
+
+use crate::components::tokens;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 #[serde(rename_all = "snake_case")]
@@ -7,103 +9,165 @@ pub enum Theme {
     #[default]
     Dark,
     Light,
-    Nord,
-    Dracula,
-    SolarizedDark,
-    SolarizedLight,
-    GruvboxDark,
 }
 
 impl Theme {
-    pub const ALL: [Theme; 7] = [
-        Theme::Dark,
-        Theme::Light,
-        Theme::Nord,
-        Theme::Dracula,
-        Theme::SolarizedDark,
-        Theme::SolarizedLight,
-        Theme::GruvboxDark,
-    ];
+    #[allow(
+        dead_code,
+        reason = "public API even though only `toggled` is used today"
+    )]
+    pub const ALL: [Theme; 2] = [Theme::Dark, Theme::Light];
 
     pub fn name(self) -> &'static str {
         match self {
             Theme::Dark => "Dark",
             Theme::Light => "Light",
-            Theme::Nord => "Nord",
-            Theme::Dracula => "Dracula",
-            Theme::SolarizedDark => "Solarized Dark",
-            Theme::SolarizedLight => "Solarized Light",
-            Theme::GruvboxDark => "Gruvbox Dark",
         }
     }
 
     pub fn is_dark(self) -> bool {
-        !matches!(self, Theme::Light | Theme::SolarizedLight)
+        matches!(self, Theme::Dark)
+    }
+
+    pub fn toggled(self) -> Self {
+        match self {
+            Theme::Dark => Theme::Light,
+            Theme::Light => Theme::Dark,
+        }
+    }
+
+    pub fn palette(self) -> Palette {
+        match self {
+            Theme::Dark => Palette::DARK,
+            Theme::Light => Palette::LIGHT,
+        }
     }
 
     pub fn visuals(self) -> Visuals {
-        match self {
-            Theme::Dark => Visuals::dark(),
-            Theme::Light => Visuals::light(),
-            _ => {
-                let palette = self.palette();
-                let mut v = if self.is_dark() {
-                    Visuals::dark()
-                } else {
-                    Visuals::light()
-                };
-                v.panel_fill = palette.panel;
-                v.window_fill = palette.panel;
-                v.faint_bg_color = palette.faint;
-                v.extreme_bg_color = palette.extreme;
-                v.window_stroke = Stroke::new(1.0, palette.border);
-                v.widgets.noninteractive.bg_fill = palette.faint;
-                v.widgets.noninteractive.bg_stroke = Stroke::new(1.0, palette.border);
-                v
-            }
-        }
+        let p = self.palette();
+        let mut v = if self.is_dark() {
+            Visuals::dark()
+        } else {
+            Visuals::light()
+        };
+
+        v.dark_mode = self.is_dark();
+        v.override_text_color = Some(p.foreground);
+        v.panel_fill = p.background;
+        v.window_fill = p.card;
+        v.window_stroke = Stroke::new(1.0, p.border);
+        v.window_corner_radius = CornerRadius::same(tokens::RADIUS_LG as u8);
+        v.window_shadow = Shadow {
+            offset: [0, 4],
+            blur: 16,
+            spread: 0,
+            color: Color32::from_black_alpha(if self.is_dark() { 96 } else { 24 }),
+        };
+        v.popup_shadow = v.window_shadow;
+        v.menu_corner_radius = CornerRadius::same(tokens::RADIUS_MD as u8);
+
+        v.faint_bg_color = p.muted;
+        v.extreme_bg_color = p.input_bg;
+        v.code_bg_color = p.muted;
+        v.hyperlink_color = p.primary;
+        v.selection.bg_fill = p.primary.gamma_multiply(0.25);
+        v.selection.stroke = Stroke::new(1.0, p.primary);
+        v.warn_fg_color = if self.is_dark() {
+            Color32::from_rgb(0xFB, 0xBF, 0x24)
+        } else {
+            Color32::from_rgb(0xCA, 0x8A, 0x04)
+        };
+        v.error_fg_color = p.destructive;
+
+        let button_radius = CornerRadius::same(tokens::RADIUS_MD as u8);
+
+        // Non-interactive widgets (separators, labels, group frames): no fill,
+        // a hairline border in the divider color. Setting bg_fill to the panel
+        // would paint over raised card surfaces.
+        v.widgets.noninteractive = WidgetVisuals {
+            bg_fill: Color32::TRANSPARENT,
+            weak_bg_fill: Color32::TRANSPARENT,
+            bg_stroke: Stroke::new(1.0, p.border),
+            corner_radius: button_radius,
+            fg_stroke: Stroke::new(1.0, p.muted_foreground),
+            expansion: 0.0,
+        };
+        // Default state for interactive widgets (buttons, combo boxes).
+        v.widgets.inactive = WidgetVisuals {
+            bg_fill: p.secondary,
+            weak_bg_fill: p.secondary,
+            bg_stroke: Stroke::new(1.0, p.border),
+            corner_radius: button_radius,
+            fg_stroke: Stroke::new(1.0, p.foreground),
+            expansion: 0.0,
+        };
+        // Hover: nudge toward accent, with a slightly stronger border.
+        v.widgets.hovered = WidgetVisuals {
+            bg_fill: p.accent,
+            weak_bg_fill: p.accent,
+            bg_stroke: Stroke::new(1.0, p.border_strong),
+            corner_radius: button_radius,
+            fg_stroke: Stroke::new(1.0, p.foreground),
+            expansion: 0.5,
+        };
+        // Pressed/active: shadcn presses look like the hovered state with a
+        // ring (handled via selection.stroke when focused).
+        v.widgets.active = WidgetVisuals {
+            bg_fill: p.accent,
+            weak_bg_fill: p.accent,
+            bg_stroke: Stroke::new(1.0, p.ring),
+            corner_radius: button_radius,
+            fg_stroke: Stroke::new(1.0, p.foreground),
+            expansion: 0.0,
+        };
+        v.widgets.open = WidgetVisuals {
+            bg_fill: p.muted,
+            weak_bg_fill: p.muted,
+            bg_stroke: Stroke::new(1.0, p.border_strong),
+            corner_radius: button_radius,
+            fg_stroke: Stroke::new(1.0, p.foreground),
+            expansion: 0.0,
+        };
+
+        v
     }
 
-    fn palette(self) -> Palette {
-        match self {
-            Theme::Nord => Palette {
-                panel: Color32::from_rgb(0x2E, 0x34, 0x40),
-                faint: Color32::from_rgb(0x3B, 0x42, 0x52),
-                extreme: Color32::from_rgb(0x43, 0x4C, 0x5E),
-                border: Color32::from_rgb(0x4C, 0x56, 0x6A),
-            },
-            Theme::Dracula => Palette {
-                panel: Color32::from_rgb(0x28, 0x2A, 0x36),
-                faint: Color32::from_rgb(0x44, 0x47, 0x5A),
-                extreme: Color32::from_rgb(0x38, 0x3A, 0x59),
-                border: Color32::from_rgb(0x62, 0x72, 0xA4),
-            },
-            Theme::SolarizedDark => Palette {
-                panel: Color32::from_rgb(0x00, 0x2B, 0x36),
-                faint: Color32::from_rgb(0x07, 0x36, 0x42),
-                extreme: Color32::from_rgb(0x0A, 0x40, 0x50),
-                border: Color32::from_rgb(0x58, 0x6E, 0x75),
-            },
-            Theme::SolarizedLight => Palette {
-                panel: Color32::from_rgb(0xFD, 0xF6, 0xE3),
-                faint: Color32::from_rgb(0xEE, 0xE8, 0xD5),
-                extreme: Color32::from_rgb(0xFC, 0xF5, 0xE2),
-                border: Color32::from_rgb(0x93, 0xA1, 0xA1),
-            },
-            Theme::GruvboxDark => Palette {
-                panel: Color32::from_rgb(0x28, 0x28, 0x28),
-                faint: Color32::from_rgb(0x3C, 0x38, 0x36),
-                extreme: Color32::from_rgb(0x50, 0x49, 0x45),
-                border: Color32::from_rgb(0x66, 0x5C, 0x54),
-            },
-            // Dark and Light use default egui visuals, so palette is unused.
-            Theme::Dark | Theme::Light => Palette {
-                panel: Color32::TRANSPARENT,
-                faint: Color32::TRANSPARENT,
-                extreme: Color32::TRANSPARENT,
-                border: Color32::TRANSPARENT,
-            },
-        }
+    /// Apply egui-wide style: spacing, fonts, and visuals. Call on init or
+    /// whenever the theme changes.
+    pub fn apply(self, ctx: &egui::Context) {
+        ctx.set_visuals(self.visuals());
+
+        let mut style = (*ctx.style()).clone();
+        style.spacing.item_spacing = egui::vec2(tokens::SPACE_2, tokens::SPACE_2);
+        style.spacing.button_padding = egui::vec2(tokens::SPACE_4, tokens::SPACE_2);
+        style.spacing.menu_margin = Margin::same(tokens::SPACE_2 as i8);
+        style.spacing.window_margin = Margin::same(tokens::SPACE_4 as i8);
+        style.spacing.indent = tokens::SPACE_4;
+        style.spacing.interact_size = egui::vec2(40.0, tokens::CONTROL_HEIGHT);
+
+        use egui::{FontFamily, FontId, TextStyle};
+        style.text_styles = [
+            (
+                TextStyle::Heading,
+                FontId::new(22.0, FontFamily::Proportional),
+            ),
+            (TextStyle::Body, FontId::new(14.0, FontFamily::Proportional)),
+            (
+                TextStyle::Monospace,
+                FontId::new(13.0, FontFamily::Monospace),
+            ),
+            (
+                TextStyle::Button,
+                FontId::new(14.0, FontFamily::Proportional),
+            ),
+            (
+                TextStyle::Small,
+                FontId::new(12.0, FontFamily::Proportional),
+            ),
+        ]
+        .into();
+
+        ctx.set_style(style);
     }
 }
 
@@ -113,11 +177,80 @@ impl std::fmt::Display for Theme {
     }
 }
 
-struct Palette {
-    panel: Color32,
-    faint: Color32,
-    extreme: Color32,
-    border: Color32,
+/// shadcn-derived palette. Names mirror the shadcn CSS variable conventions
+/// (background, foreground, primary, secondary, muted, accent, etc.).
+#[derive(Clone, Copy)]
+#[expect(
+    dead_code,
+    reason = "full palette is a design-token surface for future components"
+)]
+pub struct Palette {
+    pub background: Color32,
+    pub foreground: Color32,
+    pub card: Color32,
+    pub card_foreground: Color32,
+    pub primary: Color32,
+    pub primary_foreground: Color32,
+    pub secondary: Color32,
+    pub secondary_foreground: Color32,
+    pub muted: Color32,
+    pub muted_foreground: Color32,
+    pub accent: Color32,
+    pub accent_foreground: Color32,
+    pub destructive: Color32,
+    pub destructive_foreground: Color32,
+    pub border: Color32,
+    pub border_strong: Color32,
+    pub input_bg: Color32,
+    pub ring: Color32,
+}
+
+impl Palette {
+    /// shadcn `zinc` dark theme, tuned for a medium-grey canvas with raised
+    /// surfaces (cards lighter than the panel background, in the style of
+    /// Linear / Vercel).
+    pub const DARK: Palette = Palette {
+        background: Color32::from_rgb(0x18, 0x18, 0x1B),
+        foreground: Color32::from_rgb(0xFA, 0xFA, 0xFA),
+        card: Color32::from_rgb(0x1F, 0x1F, 0x23),
+        card_foreground: Color32::from_rgb(0xFA, 0xFA, 0xFA),
+        primary: Color32::from_rgb(0xFA, 0xFA, 0xFA),
+        primary_foreground: Color32::from_rgb(0x18, 0x18, 0x1B),
+        secondary: Color32::from_rgb(0x27, 0x27, 0x2A),
+        secondary_foreground: Color32::from_rgb(0xFA, 0xFA, 0xFA),
+        muted: Color32::from_rgb(0x27, 0x27, 0x2A),
+        muted_foreground: Color32::from_rgb(0xA1, 0xA1, 0xAA),
+        accent: Color32::from_rgb(0x2E, 0x2E, 0x33),
+        accent_foreground: Color32::from_rgb(0xFA, 0xFA, 0xFA),
+        destructive: Color32::from_rgb(0xEF, 0x44, 0x44),
+        destructive_foreground: Color32::from_rgb(0xFA, 0xFA, 0xFA),
+        border: Color32::from_rgb(0x32, 0x32, 0x38),
+        border_strong: Color32::from_rgb(0x52, 0x52, 0x5B),
+        input_bg: Color32::from_rgb(0x18, 0x18, 0x1B),
+        ring: Color32::from_rgb(0xD4, 0xD4, 0xD8),
+    };
+
+    /// shadcn `zinc` light theme.
+    pub const LIGHT: Palette = Palette {
+        background: Color32::from_rgb(0xFF, 0xFF, 0xFF),
+        foreground: Color32::from_rgb(0x09, 0x09, 0x0B),
+        card: Color32::from_rgb(0xFF, 0xFF, 0xFF),
+        card_foreground: Color32::from_rgb(0x09, 0x09, 0x0B),
+        primary: Color32::from_rgb(0x18, 0x18, 0x1B),
+        primary_foreground: Color32::from_rgb(0xFA, 0xFA, 0xFA),
+        secondary: Color32::from_rgb(0xF4, 0xF4, 0xF5),
+        secondary_foreground: Color32::from_rgb(0x18, 0x18, 0x1B),
+        muted: Color32::from_rgb(0xF4, 0xF4, 0xF5),
+        muted_foreground: Color32::from_rgb(0x71, 0x71, 0x7A),
+        accent: Color32::from_rgb(0xF4, 0xF4, 0xF5),
+        accent_foreground: Color32::from_rgb(0x18, 0x18, 0x1B),
+        destructive: Color32::from_rgb(0xDC, 0x26, 0x26),
+        destructive_foreground: Color32::from_rgb(0xFA, 0xFA, 0xFA),
+        border: Color32::from_rgb(0xE4, 0xE4, 0xE7),
+        border_strong: Color32::from_rgb(0xD4, 0xD4, 0xD8),
+        input_bg: Color32::from_rgb(0xFF, 0xFF, 0xFF),
+        ring: Color32::from_rgb(0xA1, 0xA1, 0xAA),
+    };
 }
 
 #[cfg(test)]
@@ -127,5 +260,11 @@ mod tests {
     #[test]
     fn default_is_dark() {
         assert_eq!(Theme::default(), Theme::Dark);
+    }
+
+    #[test]
+    fn toggle_round_trips() {
+        assert_eq!(Theme::Dark.toggled(), Theme::Light);
+        assert_eq!(Theme::Light.toggled(), Theme::Dark);
     }
 }

--- a/crates/cram_ui/src/ui_state.rs
+++ b/crates/cram_ui/src/ui_state.rs
@@ -55,7 +55,7 @@ mod tests {
     fn save_and_load_roundtrip() {
         let dir = tempfile::tempdir().expect("tempdir");
         let state = UiState {
-            theme: Some(Theme::Nord),
+            theme: Some(Theme::Dark),
             last_deck: Some("Rust Basics".to_string()),
         };
         state.save(dir.path()).expect("save");
@@ -81,7 +81,7 @@ mod tests {
     fn save_and_load_with_no_last_deck() {
         let dir = tempfile::tempdir().expect("tempdir");
         let state = UiState {
-            theme: Some(Theme::Dracula),
+            theme: Some(Theme::Light),
             last_deck: None,
         };
         state.save(dir.path()).expect("save");
@@ -124,10 +124,10 @@ mod tests {
     #[test]
     fn load_partial_toml_uses_defaults_for_missing_fields() {
         let dir = tempfile::tempdir().expect("tempdir");
-        std::fs::write(dir.path().join("ui_state.toml"), "theme = \"nord\"\n").expect("write");
+        std::fs::write(dir.path().join("ui_state.toml"), "theme = \"light\"\n").expect("write");
 
         let state = UiState::load(dir.path()).expect("load");
-        assert_eq!(state.theme, Some(Theme::Nord));
+        assert_eq!(state.theme, Some(Theme::Light));
         assert!(state.last_deck.is_none());
     }
 


### PR DESCRIPTION
Replaces the seven-theme picker with a Dark/Light toggle anchored on shadcn's zinc palette. The dark theme is now a medium grey (zinc-900) with raised cards (lighter than the panel) instead of the near-black flat surface it had before, and widget visuals are tuned so non-interactive surfaces stop painting over cards.

Adds a `crates/cram_ui/src/components/` module organised like shadcn — `button` (primary/secondary/outline/ghost/destructive), `card`, `input` (plus an `input_frame` helper that wraps custom `TextEdit`s with the standard border/radius without disturbing their layouter), `badge`, `separator`, and a `topbar_frame` + `nav_tab` pair. The old `style.rs` is kept as a thin shim re-exporting tokens used by code that hasn't migrated yet.

Call sites updated: topbar nav, theme toggle, error panel, conflict modal, search query, new-deck form, editor preamble/front/back inputs, and the primary/destructive/outline CTAs across the deck list, deck detail, study, sources, and editor views.

## Test plan

ci